### PR TITLE
DevNonConstB branch merged with devLite

### DIFF
--- a/source/Analysis/include/AnalyzerResolution.h
+++ b/source/Analysis/include/AnalyzerResolution.h
@@ -67,6 +67,9 @@ class AnalyzerResolution : public AnalyzerUnit {
   //! Get Csv text output for const p -> exception thrown if doesn't exist
   const CsvTextBuilder& getCsvResP() const;
 
+  //! Get Csv text output for hit collection-> exception thrown if doesn't exist
+  const CsvTextBuilder& getCsvHitCol() const;
+
  private:
 
   //! Prepare plot: fill with data & set properties; varType specifies variable type to be filled: pT, p, d0, z0, phi0, cotgTheta & scenario const pT,  const p
@@ -100,6 +103,8 @@ class AnalyzerResolution : public AnalyzerUnit {
   const double c_min_dPhi0     = 1E-4;
   const double c_max_dCtgTheta = 1.0;
   const double c_min_dCtgTheta = 1E-6;
+
+  std::unique_ptr<CsvTextBuilder> m_csvHitCol;
 
   const int    c_nBins;
 

--- a/source/Analysis/src/AnalysisManager.cc
+++ b/source/Analysis/src/AnalysisManager.cc
@@ -219,8 +219,11 @@ bool AnalysisManager::makeWebInfoPage()
     myInfo.setValue(unit->getNSimTracks());
   }
 
-  RootWInfo& myInfoBField = myContentParms.addInfo("Applied magnetic field [T]: ");
-  myInfoBField.setValue(SimParms::getInstance().magneticField()/Units::T);
+  RootWInfo& myInfoBField = myContentParms.addInfo("Applied magnetic field [T] averaged along Z: ");
+  double avgMagField = 0;
+  for (auto i=0; i<SimParms::getInstance().getNMagFieldRegions(); i++) avgMagField += SimParms::getInstance().magField[i]*Units::T;
+  avgMagField /= SimParms::getInstance().getNMagFieldRegions();
+  myInfoBField.setValue(avgMagField/Units::T);
 
   // Summary of geometry config files
   auto& simParms  = SimParms::getInstance();

--- a/source/Analysis/src/AnalysisManager.cc
+++ b/source/Analysis/src/AnalysisManager.cc
@@ -285,6 +285,15 @@ bool AnalysisManager::makeWebInfoPage()
     for (auto it=unit->getCsvResP().getCsvTextBegin(); it!=unit->getCsvResP().getCsvTextEnd(); ++it) {
       myCsvResFileP.addText(unit->getCsvResP().getCsvText(it->first));
     }
+
+    // Hit collection
+    fileName    = "HitCollection.csv";
+    webFileName = "Studied hit collections";
+    RootWTextFile& myCsvHitCol = myContentCsv.addTextFile(fileName, webFileName);
+
+    for (auto it=unit->getCsvHitCol().getCsvTextBegin(); it!=unit->getCsvHitCol().getCsvTextEnd(); ++it) {
+      myCsvHitCol.addText(unit->getCsvHitCol().getCsvText(it->first));
+    }
   }
 
   return true;

--- a/source/Analysis/src/AnalyzerMatBudget.cc
+++ b/source/Analysis/src/AnalyzerMatBudget.cc
@@ -1108,7 +1108,7 @@ void MatBudgetVisitor::visit(const BeamPipe& bp)
   double theta    = m_matTrack.getTheta();
   double eta      = m_matTrack.getEta();
   double rPos  = (bp.radius()+bp.thickness()/2.);
-  double zPos  = rPos/sin(theta);
+  double zPos  = rPos/tan(theta);
   HitPtr hit(new Hit(rPos, zPos));
   hit->setOrientation(HitOrientation::Horizontal);
   hit->setObjectKind(HitKind::Inactive);
@@ -1250,142 +1250,146 @@ void MatBudgetVisitor::analyzeModuleMB(const DetectorModule& m)
 //
 void MatBudgetVisitor::analyzeInactiveElement(std::string tag, const insur::InactiveElement& e)
 {
-  // Collision detection: rays are shot in z+ only, so only volumes in z+ need to be considered
-  // only volumes of the requested category, or those without one (which should not exist) are examined
-  if ((e.getZOffset() + e.getZLength()) > 0) {
+  // Work-out only if inactive element has non-zero material assigned, otherwise no effect of inactive material
+  if (e.getRadiationLength()!=0 || e.getInteractionLength()!=0) {
 
-    // collision detection: check eta range
-    auto etaMinMax = e.getEtaMinMax();
+    // Collision detection: rays are shot in z+ only, so only volumes in z+ need to be considered
+    // only volumes of the requested category, or those without one (which should not exist) are examined
+    if ((e.getZOffset() + e.getZLength()) > 0) {
 
-    // Volume hit
-    double eta   = m_matTrack.getEta();
-    double theta = m_matTrack.getTheta();
+      // collision detection: check eta range
+      auto etaMinMax = e.getEtaMinMax();
 
-    if ((etaMinMax.first < eta) && (etaMinMax.second > eta)) {
+      // Volume hit
+      double eta   = m_matTrack.getEta();
+      double theta = m_matTrack.getTheta();
 
-      /*
-      if (eta<0.01) {
-        std::cout << "Hitting an inactive surface at z=("
-                  << iter->getZOffset() << " to " << iter->getZOffset()+iter->getZLength()
-                  << ") r=(" << iter->getInnerRadius() << " to " << iter->getInnerRadius()+iter->getRWidth() << ")" << std::endl;
-        const std::map<std::string, double>& localMasses = iter->getLocalMasses();
-        const std::map<std::string, double>& exitingMasses = iter->getExitingMasses();
-        for (auto massIt : localMasses) std::cerr   << "       localMass" <<  massIt.first << " = " << any2str(massIt.second) << " g" << std::endl;
-        for (auto massIt : exitingMasses) std::cerr << "     exitingMass" <<  massIt.first << " = " << any2str(massIt.second) << " g" << std::endl;
-      }
-      */
+      if ((etaMinMax.first < eta) && (etaMinMax.second > eta)) {
 
-      // Initialize
-      Material material;
-      material.radiation   = 0.0;
-      material.interaction = 0.0;
-
-      double rPos = 0.0;
-      double zPos = 0.0;
-
-      // Radiation and interaction lenth scaling for vertical volumes
-      if (e.isVertical()) {
-
-        zPos = e.getZOffset() + e.getZLength() / 2.0;
-        rPos = zPos * tan(theta);
-
-        material.radiation   = e.getRadiationLength();
-        material.interaction = e.getInteractionLength();
-
-        // 2D maps for vertical surfaces
-        if (material.radiation>0){
-
-          m_radMap.Fill(zPos,rPos,material.radiation);
-          m_radMapCount.Fill(zPos,rPos);
+        /*
+        if (eta<0.01) {
+          std::cout << "Hitting an inactive surface at z=("
+                    << iter->getZOffset() << " to " << iter->getZOffset()+iter->getZLength()
+                    << ") r=(" << iter->getInnerRadius() << " to " << iter->getInnerRadius()+iter->getRWidth() << ")" << std::endl;
+          const std::map<std::string, double>& localMasses = iter->getLocalMasses();
+          const std::map<std::string, double>& exitingMasses = iter->getExitingMasses();
+          for (auto massIt : localMasses) std::cerr   << "       localMass" <<  massIt.first << " = " << any2str(massIt.second) << " g" << std::endl;
+          for (auto massIt : exitingMasses) std::cerr << "     exitingMass" <<  massIt.first << " = " << any2str(massIt.second) << " g" << std::endl;
         }
-        if (material.interaction>0) {
+        */
 
-          m_intMap.Fill(zPos,rPos,material.interaction);
-          m_intMapCount.Fill(zPos,rPos);
+        // Initialize
+        Material material;
+        material.radiation   = 0.0;
+        material.interaction = 0.0;
+
+        double rPos = 0.0;
+        double zPos = 0.0;
+
+        // Radiation and interaction lenth scaling for vertical volumes
+        if (e.isVertical()) {
+
+          zPos = e.getZOffset() + e.getZLength() / 2.0;
+          rPos = zPos * tan(theta);
+
+          material.radiation   = e.getRadiationLength();
+          material.interaction = e.getInteractionLength();
+
+          // 2D maps for vertical surfaces
+          if (material.radiation>0){
+
+            m_radMap.Fill(zPos,rPos,material.radiation);
+            m_radMapCount.Fill(zPos,rPos);
+          }
+          if (material.interaction>0) {
+
+            m_intMap.Fill(zPos,rPos,material.interaction);
+            m_intMapCount.Fill(zPos,rPos);
+          }
+
+          // Special treatment for user-defined supports as they can be very close to z=0
+          if (e.getCategory() == MaterialProperties::u_sup) {
+
+            double s = e.getZLength() / cos(theta);
+            if (s > (e.getRWidth() / sin(theta))) s = e.getRWidth() / sin(theta);
+
+            // add the hit if it's declared as inside the tracking volume, add it to 'others' if not
+            //if (e.track()) {}
+
+            material.radiation  *= s / e.getZLength();
+            material.interaction*= s / e.getZLength();
+
+            m_matBudget[tag].radiation   += material.radiation;
+            m_matBudget[tag].interaction += material.interaction;
+
+          }
+          else {
+
+            material.radiation   /= cos(theta);
+            material.interaction /= cos(theta);
+
+            m_matBudget[tag].radiation   += material.radiation;
+            m_matBudget[tag].interaction += material.interaction;
+          }
         }
-
-        // Special treatment for user-defined supports as they can be very close to z=0
-        if (e.getCategory() == MaterialProperties::u_sup) {
-
-          double s = e.getZLength() / cos(theta);
-          if (s > (e.getRWidth() / sin(theta))) s = e.getRWidth() / sin(theta);
-
-          // add the hit if it's declared as inside the tracking volume, add it to 'others' if not
-          //if (e.track()) {}
-
-          material.radiation  *= s / e.getZLength();
-          material.interaction*= s / e.getZLength();
-
-          m_matBudget[tag].radiation   += material.radiation;
-          m_matBudget[tag].interaction += material.interaction;
-
-        }
+        // Radiation and interaction length scaling for horizontal volumes
         else {
 
-          material.radiation   /= cos(theta);
-          material.interaction /= cos(theta);
+          rPos = e.getInnerRadius() + e.getRWidth() / 2.0;
+          zPos = rPos/tan(theta);
 
-          m_matBudget[tag].radiation   += material.radiation;
-          m_matBudget[tag].interaction += material.interaction;
+          material.radiation   = e.getRadiationLength();
+          material.interaction = e.getInteractionLength();
+
+          // 2D maps for vertical surfaces
+          if (material.radiation>0){
+
+            m_radMap.Fill(zPos,rPos,material.radiation);
+            m_radMapCount.Fill(zPos,rPos);
+          }
+          if (material.interaction>0) {
+
+            m_intMap.Fill(zPos,rPos,material.interaction);
+            m_intMapCount.Fill(zPos,rPos);
+           }
+
+          // Special treatment for user-defined supports; should not be necessary for now
+          // as all user-defined supports are vertical, but just in case...
+          if (e.getCategory() == MaterialProperties::u_sup) {
+
+            double s = e.getZLength() / sin(theta);
+
+            if (s > (e.getRWidth()/cos(theta))) s = e.getRWidth() / cos(theta);
+
+            // add the hit if it's declared as inside the tracking volume, add it to 'others' if not
+            //if (e.track()) {}
+
+            material.radiation  *= s / e.getZLength();
+            material.interaction*= s / e.getZLength();
+
+            m_matBudget[tag].radiation   += material.radiation;
+            m_matBudget[tag].interaction += material.interaction;
+
+          }
+          else {
+
+            material.radiation   /= sin(theta);
+            material.interaction /= sin(theta);
+
+            m_matBudget[tag].radiation   += material.radiation;
+            m_matBudget[tag].interaction += material.interaction;
+          }
         }
-      }
-      // Radiation and interaction length scaling for horizontal volumes
-      else {
 
-        rPos = e.getInnerRadius() + e.getRWidth() / 2.0;
-        zPos = rPos/tan(theta);
+        // Create Hit object with appropriate parameters, add to Track t
+        HitPtr hit(new Hit(rPos, zPos));
+        if (e.isVertical()) hit->setOrientation(HitOrientation::Vertical);
+        else                hit->setOrientation(HitOrientation::Horizontal);
+        hit->setObjectKind(HitKind::Inactive);
+        hit->setCorrectedMaterial(material);
+        m_matTrack.addHit(std::move(hit));
 
-        material.radiation   = e.getRadiationLength();
-        material.interaction = e.getInteractionLength();
-
-        // 2D maps for vertical surfaces
-        if (material.radiation>0){
-
-          m_radMap.Fill(zPos,rPos,material.radiation);
-          m_radMapCount.Fill(zPos,rPos);
-        }
-        if (material.interaction>0) {
-
-          m_intMap.Fill(zPos,rPos,material.interaction);
-          m_intMapCount.Fill(zPos,rPos);
-         }
-
-        // Special treatment for user-defined supports; should not be necessary for now
-        // as all user-defined supports are vertical, but just in case...
-        if (e.getCategory() == MaterialProperties::u_sup) {
-
-          double s = e.getZLength() / sin(theta);
-
-          if (s > (e.getRWidth()/cos(theta))) s = e.getRWidth() / cos(theta);
-
-          // add the hit if it's declared as inside the tracking volume, add it to 'others' if not
-          //if (e.track()) {}
-
-          material.radiation  *= s / e.getZLength();
-          material.interaction*= s / e.getZLength();
-
-          m_matBudget[tag].radiation   += material.radiation;
-          m_matBudget[tag].interaction += material.interaction;
-
-        }
-        else {
-
-          material.radiation   /= sin(theta);
-          material.interaction /= sin(theta);
-
-          m_matBudget[tag].radiation   += material.radiation;
-          m_matBudget[tag].interaction += material.interaction;
-        }
-      }
-
-      // Create Hit object with appropriate parameters, add to Track t
-      HitPtr hit(new Hit(rPos, zPos));
-      if (e.isVertical()) hit->setOrientation(HitOrientation::Vertical);
-      else                hit->setOrientation(HitOrientation::Horizontal);
-      hit->setObjectKind(HitKind::Inactive);
-      hit->setCorrectedMaterial(material);
-      m_matTrack.addHit(std::move(hit));
-
-    } // Eta min max
-  } // +Z check
+      } // Eta min max
+    } // +Z check
+  } // Non-zero material assigned
 }

--- a/source/Analysis/src/AnalyzerOccupancy.cc
+++ b/source/Analysis/src/AnalyzerOccupancy.cc
@@ -84,8 +84,8 @@ bool AnalyzerOccupancy::visualize(RootWSite& webSite)
   // Check that initialization & analysis OK
   if (!m_isInitOK || !m_isAnalysisOK) return false;
 
-  RootWPage& myPage = webSite.addPage("indexOccupancy", web_priority_Occup);
-  myPage.setAddress("occupancy.html");
+  RootWPage& myPage = webSite.addPage("Occupancy", web_priority_Occup);
+  myPage.setAddress("indexOccupancy.html");
 
 
   // Draw magnetic fiel - map
@@ -555,7 +555,6 @@ bool AnalyzerOccupancy::visualize(RootWSite& webSite)
             senAddrSparSize[iSensor]   = m_layerSenAddrSparSize[iLayer][iSensor] + addrSparClsWidth;
             senAddrUnsparSize[iSensor] = m_layerSenAddrUnsparSize[iLayer][iSensor];
 
-            std::cout << ">iLayer>>" << iLayer << " " << channelRate[iSensor] << " " << senAddrSparSize[iSensor] << "  " << m_layerNModules[iLayer] << std::endl;
             totHitRate        += hitRate[iSensor];
             totChannelRate    += channelRate[iSensor];
             totAddrSparSize   += senAddrSparSize[iSensor];
@@ -569,7 +568,6 @@ bool AnalyzerOccupancy::visualize(RootWSite& webSite)
             dataRateUnTriggerSpar += channelRate[iSensor]*senAddrSparSize[iSensor];
           }
 
-          std::cout << ">>> " << dataRateCollisionSpar << std::endl;
           dataRateTriggerSpar   *= trigger_freq;
           dataRateUnTriggerSpar *= collision_freq;
 

--- a/source/Analysis/src/AnalyzerResolution.cc
+++ b/source/Analysis/src/AnalyzerResolution.cc
@@ -557,7 +557,7 @@ void AnalyzerResolution::preparePlot(std::vector<unique_ptr<TProfile>>& profHisA
       if (varType=="pT")        yVal = track->getDeltaPtOverPt()*100; // In percent
       if (varType=="p")         yVal = track->getDeltaPOverP()*100;   // In percent
       if (varType=="d0")        yVal = track->getDeltaD0()/Units::um;
-      if (varType=="z0")        yVal = track->getDeltaZ0()/Units::um;
+      if (varType=="z0")        yVal = track->getDeltaZ0(0)/Units::um; // Estimate @ [r.z] = [0,0], hence @ s=0
       if (varType=="phi0")      yVal = track->getDeltaPhi()/M_PI*180.; // In degerees
       if (varType=="cotgTheta") yVal = track->getDeltaCtgTheta();
 

--- a/source/Analysis/src/AnalyzerResolution.cc
+++ b/source/Analysis/src/AnalyzerResolution.cc
@@ -54,6 +54,7 @@ bool AnalyzerResolution::init(int nTracks)
     // Prepare Csv containers -> keep final pT/p resolution in csv file
     m_csvResPt = std::unique_ptr<CsvTextBuilder>(new CsvTextBuilder());
     m_csvResP  = std::unique_ptr<CsvTextBuilder>(new CsvTextBuilder());
+    m_csvHitCol= std::unique_ptr<CsvTextBuilder>(new CsvTextBuilder());
 
     m_csvResPt->addCsvElement("Label", "Tag name");
     m_csvResPt->addCsvElement("Label", "Resolution type");
@@ -62,6 +63,10 @@ bool AnalyzerResolution::init(int nTracks)
     m_csvResP->addCsvElement("Label", "Tag name");
     m_csvResP->addCsvElement("Label", "Resolution type");
     m_csvResP->addCsvElement("Label", "Total momentum [GeV]");
+
+    m_csvHitCol->addCsvElement("Label", "Eta");
+    m_csvHitCol->addCsvElement("Label", "BPHit");
+    m_csvHitCol->addCsvElement("Label", "NxDetHits (s_R:s_Z:X/X0@Eta)");
 
     for (unsigned int iBorder=0; iBorder<SimParms::getInstance().getNEtaRegions()-1; ++iBorder) {
 
@@ -73,6 +78,7 @@ bool AnalyzerResolution::init(int nTracks)
 
     m_csvResPt->addCsvEOL("Label");
     m_csvResP->addCsvEOL("Label");
+    m_csvHitCol->addCsvEOL("Label");
 
     m_isInitOK = true;
     return m_isInitOK;
@@ -109,8 +115,21 @@ bool AnalyzerResolution::analyze()
 
     // Assign material to the track
     MatTrackVisitor matVisitor(matTrack);
-    for (auto iTracker : m_trackers) iTracker->accept(matVisitor);  // Assign to material track hits corresponding to modules
     m_beamPipe->accept(matVisitor);                                 // Assign to material track hit corresponding to beam-pipe
+    for (auto iTracker : m_trackers) iTracker->accept(matVisitor);  // Assign to material track hits corresponding to modules
+
+    // Output hits to a file for debuggin purposes
+    m_csvHitCol->addCsvElement(std::string("LastEta="+any2str(eta, 2)), any2str(eta, 2));
+
+    std::map<double, std::string> hitInfoRSorted;
+    for (std::vector<std::unique_ptr<Hit>>::const_iterator iter=matTrack.getBeginHits(); iter!=matTrack.getEndHits(); iter++) {
+
+      std::string hitInfo = any2str((*iter)->getRPos()/Units::mm,1)+":"+any2str((*iter)->getZPos()/Units::mm,1)+":"+any2str((*iter)->getCorrectedMaterial().radiation, 6);
+      hitInfoRSorted[(*iter)->getRPos()] = hitInfo;
+    }
+    for (auto& iMap : hitInfoRSorted) m_csvHitCol->addCsvElement(std::string("LastEta="+any2str(eta, 2)), iMap.second);
+    hitInfoRSorted.clear();
+    m_csvHitCol->addCsvEOL(std::string("LastEta="+any2str(eta, 2)));
 
     // Go through tracks with non-zero number of hits
     if (!matTrack.hasNoHits()) {
@@ -502,6 +521,18 @@ const CsvTextBuilder& AnalyzerResolution::getCsvResP() const
 }
 
 //
+// Get Csv text output for hit collection-> exception thrown if doesn't exist
+//
+const CsvTextBuilder& AnalyzerResolution::getCsvHitCol() const
+{
+  // Check if exist
+  if (m_csvHitCol) return *m_csvHitCol;
+
+  // Otherwise throw exception
+  else throw std::invalid_argument( "CsvTextBuilder::getCsvHitCol() - csvHitCol not defined (null reference), check!!!" );
+}
+
+//
 // Prepare plot: fill with data & set properties; varType specifies variable type to be filled: pT, p, d0, z0, phi0, cotgTheta
 //
 void AnalyzerResolution::preparePlot(std::vector<unique_ptr<TProfile>>& profHisArray, std::string varType, std::string scenario, const std::map<int, TrackCollection>& mapCollection)
@@ -554,11 +585,14 @@ void AnalyzerResolution::preparePlot(std::vector<unique_ptr<TProfile>>& profHisA
 
       double xVal = track->getEta();
       double yVal = 0;
-      if (varType=="pT")        yVal = track->getDeltaPtOverPt()*100; // In percent
-      if (varType=="p")         yVal = track->getDeltaPOverP()*100;   // In percent
-      if (varType=="d0")        yVal = track->getDeltaD0()/Units::um;
-      if (varType=="z0")        yVal = track->getDeltaZ0(0)/Units::um; // Estimate @ [r.z] = [0,0], hence @ s=0
-      if (varType=="phi0")      yVal = track->getDeltaPhi()/M_PI*180.; // In degerees
+
+      // Evaluate at reference point [r,z] =[0,0]
+      double rPos = 0.0;
+      if (varType=="pT")        yVal = track->getDeltaPtOverPt(rPos)*100; // In percent
+      if (varType=="p")         yVal = track->getDeltaPOverP(rPos)*100;   // In percent
+      if (varType=="d0")        yVal = track->getDeltaD0(rPos)/Units::um;
+      if (varType=="z0")        yVal = track->getDeltaZ0(rPos)/Units::um;
+      if (varType=="phi0")      yVal = track->getDeltaPhi0(rPos)/M_PI*180.; // In degerees
       if (varType=="cotgTheta") yVal = track->getDeltaCtgTheta();
 
       profHis->Fill(xVal, yVal);
@@ -858,7 +892,8 @@ void MatTrackVisitor::visit(const BeamPipe& bp)
   double theta = m_matTrack.getTheta();
   double eta   = m_matTrack.getEta();
   double rPos  = (bp.radius()+bp.thickness()/2.);
-  double zPos  = rPos/sin(theta);
+  double zPos  = rPos/tan(theta);
+
   HitPtr hit(new Hit(rPos, zPos));
   hit->setOrientation(HitOrientation::Horizontal);
   hit->setObjectKind(HitKind::Inactive);
@@ -878,8 +913,8 @@ void MatTrackVisitor::visit(const BeamPipe& bp)
 void MatTrackVisitor::visit(const Barrel& b)
 {
   for (auto& element : b.services()) {
-      analyzeInactiveElement(element);
-    }
+    analyzeInactiveElement(element);
+  }
 }
 
 //
@@ -965,104 +1000,108 @@ void MatTrackVisitor::analyzeModuleMB(const DetectorModule& m)
 //
 void MatTrackVisitor::analyzeInactiveElement(const insur::InactiveElement& e)
 {
-  // Collision detection: rays are shot in z+ only, so only volumes in z+ need to be considered
-  // only volumes of the requested category, or those without one (which should not exist) are examined
-  if ((e.getZOffset() + e.getZLength()) > 0) {
+  // Work-out only if inactive element has non-zero material assigned, otherwise no effect of inactive material
+  if (e.getRadiationLength()!=0 || e.getInteractionLength()!=0) {
 
-    // collision detection: check eta range
-    auto etaMinMax = e.getEtaMinMax();
+    // Collision detection: rays are shot in z+ only, so only volumes in z+ need to be considered
+    // only volumes of the requested category, or those without one (which should not exist) are examined
+    if ((e.getZOffset() + e.getZLength()) > 0) {
 
-    // Volume hit
-    double eta   = m_matTrack.getEta();
-    double theta = m_matTrack.getTheta();
+      // collision detection: check eta range
+      auto etaMinMax = e.getEtaMinMax();
 
-    if ((etaMinMax.first < eta) && (etaMinMax.second > eta)) {
+      // Volume hit
+      double eta   = m_matTrack.getEta();
+      double theta = m_matTrack.getTheta();
 
-      /*
-      if (eta<0.01) {
-        std::cout << "Hitting an inactive surface at z=("
-                  << iter->getZOffset() << " to " << iter->getZOffset()+iter->getZLength()
-                  << ") r=(" << iter->getInnerRadius() << " to " << iter->getInnerRadius()+iter->getRWidth() << ")" << std::endl;
-        const std::map<std::string, double>& localMasses = iter->getLocalMasses();
-        const std::map<std::string, double>& exitingMasses = iter->getExitingMasses();
-        for (auto massIt : localMasses) std::cerr   << "       localMass" <<  massIt.first << " = " << any2str(massIt.second) << " g" << std::endl;
-        for (auto massIt : exitingMasses) std::cerr << "     exitingMass" <<  massIt.first << " = " << any2str(massIt.second) << " g" << std::endl;
-      }
-      */
+      if ((etaMinMax.first < eta) && (etaMinMax.second > eta)) {
 
-      // Initialize
-      Material material;
-      material.radiation   = 0.0;
-      material.interaction = 0.0;
-
-      double rPos = 0.0;
-      double zPos = 0.0;
-
-      // Radiation and interaction lenth scaling for vertical volumes
-      if (e.isVertical()) {
-
-        zPos = e.getZOffset() + e.getZLength() / 2.0;
-        rPos = zPos * tan(theta);
-
-        material.radiation   = e.getRadiationLength();
-        material.interaction = e.getInteractionLength();
-
-        // Special treatment for user-defined supports as they can be very close to z=0
-        if (e.getCategory() == MaterialProperties::u_sup) {
-
-          double s = e.getZLength() / cos(theta);
-          if (s > (e.getRWidth() / sin(theta))) s = e.getRWidth() / sin(theta);
-
-          // add the hit if it's declared as inside the tracking volume, add it to 'others' if not
-          //if (e.track()) {}
-
-          material.radiation  *= s / e.getZLength();
-          material.interaction*= s / e.getZLength();
+        /*
+        if (eta<0.01) {
+          std::cout << "Hitting an inactive surface at z=("
+                    << iter->getZOffset() << " to " << iter->getZOffset()+iter->getZLength()
+                    << ") r=(" << iter->getInnerRadius() << " to " << iter->getInnerRadius()+iter->getRWidth() << ")" << std::endl;
+          const std::map<std::string, double>& localMasses = iter->getLocalMasses();
+          const std::map<std::string, double>& exitingMasses = iter->getExitingMasses();
+          for (auto massIt : localMasses) std::cerr   << "       localMass" <<  massIt.first << " = " << any2str(massIt.second) << " g" << std::endl;
+          for (auto massIt : exitingMasses) std::cerr << "     exitingMass" <<  massIt.first << " = " << any2str(massIt.second) << " g" << std::endl;
         }
+        */
+
+        // Initialize
+        Material material;
+        material.radiation   = 0.0;
+        material.interaction = 0.0;
+
+        double rPos = 0.0;
+        double zPos = 0.0;
+
+        // Radiation and interaction lenth scaling for vertical volumes
+        if (e.isVertical()) {
+
+          zPos = e.getZOffset() + e.getZLength() / 2.0;
+          rPos = zPos * tan(theta);
+
+          material.radiation   = e.getRadiationLength();
+          material.interaction = e.getInteractionLength();
+
+          // Special treatment for user-defined supports as they can be very close to z=0
+          if (e.getCategory() == MaterialProperties::u_sup) {
+
+            double s = e.getZLength() / cos(theta);
+            if (s > (e.getRWidth() / sin(theta))) s = e.getRWidth() / sin(theta);
+
+            // add the hit if it's declared as inside the tracking volume, add it to 'others' if not
+            //if (e.track()) {}
+
+            material.radiation  *= s / e.getZLength();
+            material.interaction*= s / e.getZLength();
+          }
+          else {
+
+            material.radiation   /= cos(theta);
+            material.interaction /= cos(theta);
+          }
+        }
+        // Radiation and interaction length scaling for horizontal volumes
         else {
 
-          material.radiation   /= cos(theta);
-          material.interaction /= cos(theta);
+          rPos = e.getInnerRadius() + e.getRWidth() / 2.0;
+          zPos = rPos/tan(theta);
+
+          material.radiation   = e.getRadiationLength();
+          material.interaction = e.getInteractionLength();
+
+          // Special treatment for user-defined supports; should not be necessary for now
+          // as all user-defined supports are vertical, but just in case...
+          if (e.getCategory() == MaterialProperties::u_sup) {
+
+            double s = e.getZLength() / sin(theta);
+
+            if (s > (e.getRWidth()/cos(theta))) s = e.getRWidth() / cos(theta);
+
+            // add the hit if it's declared as inside the tracking volume, add it to 'others' if not
+            //if (e.track()) {}
+
+            material.radiation  *= s / e.getZLength();
+            material.interaction*= s / e.getZLength();
+          }
+          else {
+
+            material.radiation   /= sin(theta);
+            material.interaction /= sin(theta);
+          }
         }
-      }
-      // Radiation and interaction length scaling for horizontal volumes
-      else {
 
-        rPos = e.getInnerRadius() + e.getRWidth() / 2.0;
-        zPos = rPos/tan(theta);
+        // Create Hit object with appropriate parameters, add to Track t
+        HitPtr hit(new Hit(rPos, zPos));
+        if (e.isVertical()) hit->setOrientation(HitOrientation::Vertical);
+        else                hit->setOrientation(HitOrientation::Horizontal);
+        hit->setObjectKind(HitKind::Inactive);
+        hit->setCorrectedMaterial(material);
+        m_matTrack.addHit(std::move(hit));
 
-        material.radiation   = e.getRadiationLength();
-        material.interaction = e.getInteractionLength();
-
-        // Special treatment for user-defined supports; should not be necessary for now
-        // as all user-defined supports are vertical, but just in case...
-        if (e.getCategory() == MaterialProperties::u_sup) {
-
-          double s = e.getZLength() / sin(theta);
-
-          if (s > (e.getRWidth()/cos(theta))) s = e.getRWidth() / cos(theta);
-
-          // add the hit if it's declared as inside the tracking volume, add it to 'others' if not
-          //if (e.track()) {}
-
-          material.radiation  *= s / e.getZLength();
-          material.interaction*= s / e.getZLength();
-        }
-        else {
-
-          material.radiation   /= sin(theta);
-          material.interaction /= sin(theta);
-        }
-      }
-
-      // Create Hit object with appropriate parameters, add to Track t
-      HitPtr hit(new Hit(rPos, zPos));
-      if (e.isVertical()) hit->setOrientation(HitOrientation::Vertical);
-      else                hit->setOrientation(HitOrientation::Horizontal);
-      hit->setObjectKind(HitKind::Inactive);
-      hit->setCorrectedMaterial(material);
-      m_matTrack.addHit(std::move(hit));
-
-    } // Eta min max
-  } // +Z check
+      } // Eta min max
+    } // +Z check
+  } // Non-zero material assigned
 }

--- a/source/Geometry/src/DetectorModule.cc
+++ b/source/Geometry/src/DetectorModule.cc
@@ -242,7 +242,7 @@ double DetectorModule::resolutionEquivalentRPhi(double hitRho, double trackR) co
 
   // Parameters
   double A = hitRho/(2*trackR); // r_i / 2R
-  A = 0; // For debugging purposes
+  //A = 0; // For debugging purposes
   double B = A/sqrt(1-A*A);
 
   // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)
@@ -259,7 +259,7 @@ double DetectorModule::resolutionEquivalentZ(double hitRho, double trackR, doubl
 
   // Parameters
   double A = hitRho/(2*trackR); 
-  A = 0; // For debugging purposes
+  //A = 0; // For debugging purposes
   double D = trackCotgTheta/sqrt(1-A*A);
 
   // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)

--- a/source/Geometry/src/DetectorModule.cc
+++ b/source/Geometry/src/DetectorModule.cc
@@ -242,6 +242,7 @@ double DetectorModule::resolutionEquivalentRPhi(double hitRho, double trackR) co
 
   // Parameters
   double A = hitRho/(2*trackR); // r_i / 2R
+  A = 0; // For debugging purposes
   double B = A/sqrt(1-A*A);
 
   // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)
@@ -258,6 +259,7 @@ double DetectorModule::resolutionEquivalentZ(double hitRho, double trackR, doubl
 
   // Parameters
   double A = hitRho/(2*trackR); 
+  A = 0; // For debugging purposes
   double D = trackCotgTheta/sqrt(1-A*A);
 
   // All modules & its resolution propagated to the resolution of a virtual barrel module (endcap is a tilted module by 90 degrees, barrel is tilted by 0 degrees)

--- a/source/Tools/include/SimParms.h
+++ b/source/Tools/include/SimParms.h
@@ -39,7 +39,7 @@ class SimParms : public PropertyObject, public Buildable, public Visitable {
   //! SimParms visitable -> implememented const accept method to call visitor pattern
   void accept(ConstGeometryVisitor& v) const;
 
-  //! Cross-check that Sim parameters correctly read-in from the file
+  //! Cross-check that Sim parameters correctly read-in from the file & set units
   void crosscheck();
 
   //! Set command line options passed over to program to analyze data
@@ -96,6 +96,12 @@ class SimParms : public PropertyObject, public Buildable, public Visitable {
   //! Get eta max value as defined by user in definition of various tracker eta regions
   double getMaxEtaCoverage() const { if (etaRegionRanges.size()>0) return etaRegionRanges[etaRegionRanges.size()-1]; else return 0.0; }
 
+  //! Check whether magnetic field const. or defined as a function
+  bool isMagFieldConst() const { if (magField.size()==1) return true; else return false;}
+
+  //! Get number of defined mag. field regions
+  size_t getNMagFieldRegions() const { return magFieldZRegions.size(); }
+
   //! Get reference to irradiation maps manager
   const IrradiationMapsManager& irradiationMapsManager() const { return *m_irradiationMapsManager;}
 
@@ -121,12 +127,8 @@ class SimParms : public PropertyObject, public Buildable, public Visitable {
   ReadonlyProperty<double, Default>   alphaParm;
   ReadonlyProperty<double, Default>   referenceTemp;
 
-  ReadonlyProperty<double, Default>   magneticField;        //!< Central magnetic field in Tesla
-
-  // To include dipole region in a quick way
-  ReadonlyProperty<double, Default>   dipoleMagneticField;  //!< Dipole integral magnetic field in [Tm]
-  ReadonlyProperty<double, Default>   dipoleDPlResAt10TeV;  //!< Dipole deltaPl/Pl resolution of dipole tracker at 10 TeV
-  ReadonlyProperty<double, Default>   dipoleXToX0;          //  [%]
+  ReadonlyPropertyVector<double, ','> magField;             //!< Magnetic field [T] as a vector of approximate values of B(z) in predefined regions 0-z0, z0-z1, ...
+  ReadonlyPropertyVector<double, ','> magFieldZRegions;     //!< Regions [m], in which the magnetic field values (B(z)) are defined, regions defined as a sequence of z0 [m], z1 [m], ... -> intervals 0-z0; z0-z1, etc.
 
   PropertyVector<std::string, ','>    irradiationMapFiles;
 
@@ -135,7 +137,7 @@ class SimParms : public PropertyObject, public Buildable, public Visitable {
   ReadonlyPropertyVector<double     , ','> etaRegionRanges; //!< Set ordered eta regions, the last one being maximum tracker eta coverage (e.g. 0, 2.5, 4.0)
   ReadonlyPropertyVector<std::string, ','> etaRegionNames;  //!< Set names for ordered eta borders (e.g TRK-0, TRK-BRL, TRK-MAX)
 
-  Property<std::string, Default> bFieldMapFile;           // Map of b field - not currently currently for tracking
+  Property<std::string, Default> bFieldMapFile;           // Map of b field - currently forvisualization use only (not for tracking)
   Property<std::string, Default> chargedMapFile;          // Map of charged hadron fluxes, segmented in R x Z
   Property<std::string, Default> chargedMapLowThFile;     // Map of charged hadron fluxes - electrons with lower threshold, segmented in R x Z
   Property<std::string, Default> chargedMapBOffMatOnFile; // Map of charged hadron fluxes, segmented in R x Z, no mag. field applied

--- a/source/Tools/src/SimParms.cc
+++ b/source/Tools/src/SimParms.cc
@@ -2,6 +2,7 @@
 
 #include <MainConfigHandler.h>
 #include "global_constants.h"
+#include "Units.h"
 #include "Visitor.h"
 #include "IrradiationMapsManager.h"
 
@@ -36,10 +37,8 @@ SimParms::SimParms() :
  chargeDepletionVoltage(  "chargeDepletionVoltage"  , parsedOnly(), 600),
  alphaParm(               "alphaParm"               , parsedOnly(), 4e-17),
  referenceTemp(           "referenceTemp"           , parsedOnly(), 20),
- magneticField(           "magneticField"           , parsedOnly(), magnetic_field),
- dipoleMagneticField(     "dipoleMagneticField"     , parsedOnly(), 0.0),
- dipoleDPlResAt10TeV(     "dipoleDPlResAt10TeV"     , parsedOnly(), 0.1),
- dipoleXToX0(             "dipoleXToX0"             , parsedOnly(), 0.1),
+ magField(                "magField"                , parsedOnly()),
+ magFieldZRegions(        "magFieldZRegions"        , parsedOnly()),
  irradiationMapFiles(     "irradiationMapFiles"     , parsedAndChecked()),
  etaRegionRanges(         "etaRegionRanges"         , parsedAndChecked()),
  etaRegionNames(          "etaRegionNames"          , parsedAndChecked()),
@@ -84,7 +83,7 @@ SimParms::~SimParms()
 }
 
 //
-// Check that sim parameters read-in correctly
+// Check that sim parameters read-in correctly & set units
 //
 void SimParms::crosscheck() {
   try {
@@ -95,6 +94,20 @@ void SimParms::crosscheck() {
 
   // Check that sizes of eta vectors: names & ranges are the same
   if (etaRegionNames.size()!=etaRegionRanges.size()) throw PathfulException("Number of names assigned to individual eta regions don't correspond to number of defined eta regions, check the config file!" , "SimParms");
+
+  // Check that number of magnetic field values correspond to number of magnetic field intervals
+  if (magField.size()!=magFieldZRegions.size()) throw PathfulException("Number of magnetic field values doesn't correspond to number of intervals!" , "SimParms");
+
+  // Check that magnetic field non-zero in at least one interval
+  bool nonZero = false;
+  for (auto i=0; i<magFieldZRegions.size(); i++) {
+    if (magField[i]>0) nonZero = true;
+  }
+  if (nonZero!=true) throw PathfulException("Magnetic field needs to be defined non-zero in at least one Z interval!" , "SimParms");
+
+  // Set expected default units
+  magField.scaleByUnit(Units::T);
+  magFieldZRegions.scaleByUnit(Units::m);
 }
 
 //

--- a/source/Tracking/include/Hit.h
+++ b/source/Tracking/include/Hit.h
@@ -67,8 +67,9 @@ public:
   void setPixel(bool isPixel)                       { m_isPixel = isPixel;}
   void setBeamPipe(bool isBeamPipe)                 { m_isBeamPipe = isBeamPipe;}
   void setTrigger(bool isTrigger)                   { m_isTrigger = isTrigger;}
-  void setResolutionRphi(double newRes)             { m_resolutionRphi = newRes; } // Only used for virtual hits on non-modules
-  void setResolutionY(double newRes)                { m_resolutionY = newRes; } // Only used for virtual hits on non-modules
+  void setResolutionRphi(double newRes)             { m_resolutionRPhi = newRes; } // Only used for virtual hits on non-modules
+  void setResolutionZ(double newRes)                { m_resolutionZ = newRes; }    // Only used for virtual hits on non-modules
+  void setResolutionY(double newRes)                { setResolutionZ(newRes); } // Used for compatibility only -> use setResolutionZ(double newRes) instead
   bool setIP(bool newIP)                            { return m_isIP = newIP; }
   void setActiveHitType(HitType activeHitType)      { m_activeHitType = activeHitType; }
 
@@ -119,8 +120,8 @@ private:
   
   double getTrackTheta();
 
-  double m_resolutionRphi; // Only used for virtual hits on non-modules
-  double m_resolutionY;    // Only used for virtual hits on non-modules
+  double m_resolutionRPhi; // Only used for virtual hits on non-modules
+  double m_resolutionZ;    // Only used for virtual hits on non-modules
 
 }; // Class
 

--- a/source/Tracking/include/Track.h
+++ b/source/Tracking/include/Track.h
@@ -166,6 +166,11 @@ protected:
   //! Compute the covariance matrix of the track parameters in R-Phi projection
   void computeCovarianceMatrixRPhi();
 
+  //! Helper fce returning derivative: df(rho, d0, phi0)/drho, where f approximates
+  //! a helix by set of parabolas. In general, N connected parabolas used, for const B
+  //! field only one parabola applied.
+  double computeDfOverDRho(double rPos, double zPos);
+
   double m_theta;              //!< Track shot at given theta & phi, i.e. theta at primary vertex
   double m_phi;                //!< Track shot at given theta & phi, i.e. phi at primary vertex
   double m_cotgTheta;          //!< Automatically calculated from theta at [0,0]

--- a/source/Tracking/src/Hit.cc
+++ b/source/Tracking/src/Hit.cc
@@ -60,8 +60,8 @@ Hit::Hit() {
     m_isTrigger        = false;
     m_isIP             = false;
     m_isBeamPipe       = false;
-    m_resolutionRphi   = 0;
-    m_resolutionY      = 0;
+    m_resolutionRPhi   = 0;
+    m_resolutionZ      = 0;
     m_activeHitType    = HitType::NONE;
 }
 
@@ -82,8 +82,8 @@ Hit::Hit(const Hit& h) {
     m_isTrigger         = h.m_isTrigger;
     m_isIP              = h.m_isIP;
     m_isBeamPipe        = h.m_isBeamPipe;
-    m_resolutionRphi    = h.m_resolutionRphi;
-    m_resolutionY       = h.m_resolutionY;
+    m_resolutionRPhi    = h.m_resolutionRPhi;
+    m_resolutionZ       = h.m_resolutionZ;
     m_activeHitType     = h.m_activeHitType;
 }
 
@@ -102,8 +102,8 @@ Hit::Hit(double rPos, double zPos) {
     m_isPixel          = false;
     m_isIP             = false;
     m_isBeamPipe       = false;
-    m_resolutionRphi   = 0;
-    m_resolutionY      = 0;
+    m_resolutionRPhi   = 0;
+    m_resolutionZ      = 0;
     m_activeHitType    = HitType::NONE;
 }
 
@@ -123,8 +123,8 @@ Hit::Hit(double rPos, double zPos, const DetectorModule* myModule, HitType activ
     m_isPixel          = false;
     m_isIP             = false;
     m_isBeamPipe       = false;
-    m_resolutionRphi   = 0;
-    m_resolutionY      = 0;
+    m_resolutionRPhi   = 0;
+    m_resolutionZ      = 0;
     m_activeHitType    = activeHitType;
 }
 
@@ -189,7 +189,7 @@ double Hit::getResolutionRphi(double trackRadius) {
      // if (isTrigger_) return hitModule_->resolutionRPhiTrigger();
      // else return hitModule_->resolutionRPhi();
     }
-    else return m_resolutionRphi;
+    else return m_resolutionRPhi;
   }
 }
 
@@ -222,7 +222,7 @@ double Hit::getResolutionZ(double trackRadius) {
       //if (isTrigger_) return hitModule_->resolutionYTrigger();
       //else return hitModule_->resolutionY();
     }
-    else return m_resolutionY;
+    else return m_resolutionZ;
   }
 }
 


### PR DESCRIPTION
* Tracking in non-const mag. field implemented for use case of B=B(z) only, radial or phi component is required to be zero -> N parabola approximation practically used. Several limitations of this approach need to be kept in mind for now: error propagated locally along line only in such case, no helix corrections used (minor effect).
* Track class properly documented, used standard mathematical description for cov, var variables etc.
* Full track propagator implemented - track parameters can be estimated anywhere on the track (if non-const. mag. field case studied, propagators will throw warning and return value at [r,z]=[0,0], dedicated mathematics needs to be still implemented if propagator in non-const. B field studied).
* Beam-pipe hit bug fixed.