### PR TITLE
Merging masterLite with devLite

### DIFF
--- a/geometries/FCC/FCChh_v3.03/FCChh_v3.03.cfg
+++ b/geometries/FCC/FCChh_v3.03/FCChh_v3.03.cfg
@@ -16,12 +16,13 @@
 //
 BeamPipe Pipe {
 
-// Beam-pipe: original shape without flanges
-    radiusLower    20.00,20.00,20.00  // mm (N-points)
-    radiusUpper    20.80,20.80,20.00  // mm (N-points: enclose the shape by upper R, for segments with different material)
-    zPos           0.000,18000,18000  // mm (N-points)
-    radLength      352.8,352.8        // (N-1 segments) Zero reflects fact that ending shape is defined by just a point 
-    intLength      421.0,421.0        // (N-1 segmetns)
+// 2D Beam-pipe: original shape withou flanges
+    radius         20.00,20.00 // mm (N-points defining contour)
+    zPos           0.000,18000 // mm (N-points defining contour)
+    thickness      0.8         // N-1 segments thickness in mm
+    radLength      352.8       // N-1 segments rad. length in mm
+    intLength      421.0       // N-1 segments int. length in mm
+
 }
 
 //

--- a/source/Analysis/src/AnalyzerGeometry.cc
+++ b/source/Analysis/src/AnalyzerGeometry.cc
@@ -670,8 +670,8 @@ void AnalyzerGeometry::drawBeamPipeRZ(TCanvas& canvas, double maxZ, bool bothPls
       float iSign = (i>=0) ? +1 : -1;
       int   iAbs  = abs(i);
 
-      double bpRadiusLower = m_beamPipe->radiusLower[iAbs];
-      double bpRadiusUpper = m_beamPipe->radiusUpper[iAbs];
+      double bpRadiusLower = m_beamPipe->getRadiusLower(iAbs);
+      double bpRadiusUpper = m_beamPipe->getRadiusUpper(iAbs);
       double bpZPos        = iSign*m_beamPipe->zPos[iAbs];
 
       // Linearize if beam-pipe defined in Z beyond the drawing +-Z window
@@ -685,8 +685,8 @@ void AnalyzerGeometry::drawBeamPipeRZ(TCanvas& canvas, double maxZ, bool bothPls
 
           bpZPos   = iSign*maxZ*vis_safety_factor;
 
-          bpRadiusLower = (fabs(bpZPos)-m_beamPipe->zPos[iAbs-1])*m_beamPipe->getTiltLower(iAbs-1) + m_beamPipe->radiusLower[iAbs-1];
-          bpRadiusUpper = (fabs(bpZPos)-m_beamPipe->zPos[iAbs-1])*m_beamPipe->getTiltUpper(iAbs-1) + m_beamPipe->radiusUpper[iAbs-1];
+          bpRadiusLower = (fabs(bpZPos)-m_beamPipe->zPos[iAbs-1])*m_beamPipe->getTiltLower(iAbs-1) + m_beamPipe->getRadiusLower(iAbs-1);
+          bpRadiusUpper = (fabs(bpZPos)-m_beamPipe->zPos[iAbs-1])*m_beamPipe->getTiltUpper(iAbs-1) + m_beamPipe->getRadiusUpper(iAbs-1);
         }
       }
 
@@ -728,8 +728,8 @@ void AnalyzerGeometry::drawBeamPipeXY(TCanvas& canvas)
     // Get radii & sort them from highest to lowest (not to overdraw their shape in the end)
     for (auto i=0; i<=m_beamPipe->getNSegments(); i++) {
 
-      double bpRadiusLower = m_beamPipe->radiusLower[i];
-      double bpRadiusUpper = m_beamPipe->radiusUpper[i];
+      double bpRadiusLower = m_beamPipe->getRadiusLower(i);
+      double bpRadiusUpper = m_beamPipe->getRadiusUpper(i);
       double bpZPos        = m_beamPipe->zPos[i];
       bpRZ.insert(std::pair<double,double>(bpRadiusLower,bpZPos));
       bpRZ.insert(std::pair<double,double>(bpRadiusUpper,bpZPos));

--- a/source/Analysis/src/AnalyzerMatBudget.cc
+++ b/source/Analysis/src/AnalyzerMatBudget.cc
@@ -22,6 +22,7 @@
 #include "RootWPage.h"
 #include "RootWSite.h"
 #include "RootWTable.h"
+#include "SimParms.h"
 #include "SupportStructure.h"
 #include <TCanvas.h>
 #include <TColor.h>
@@ -1105,209 +1106,41 @@ VisitorMatBudget::~VisitorMatBudget()
 void VisitorMatBudget::visit(const BeamPipe& bp)
 {
   //
-  // Add hit corresponding with beam-pipe
-  double theta = m_matTrack.getTheta();
-  //double eta   = m_matTrack.getEta();
-  double z0    = m_matTrack.getOrigin().Z();
+  // Add hits created within the beam-pipe (may be several hits if beam-pipe tilted & luminous region of non-zero sigma)
+  XYZVector  direction(m_matTrack.getDirection());
 
-  // Eta assumed to be positive so, theta between 0-90deg, hence material is always given as firstUpper-firstLower hit, secondUpper-secondLower etc. -> sort from lowest to highest Z
-  std::vector<std::pair<double,double>> bpZRLower;
-  std::vector<std::pair<double,double>> bpZRUpper;
-  std::vector<std::pair<double,double>> bpRadIntLength;
+  std::vector<Material*>                  hitMaterialVec;
+  std::vector<ROOT::Math::RhoZPhiVector*> hitPosVec;
 
-  // Check all segments from negative to positive part of the beam-pipe & create crossing points with beam-pipe contours (lower & upper)
-  // Upper contour is asssumed to close-up the beam-pipe segments containing a certain material, e.g. beam-pipe constructed from central Be & aluminium flanges
-  // If beam-pipe consists of 1 material only, the upper contour will close-up just the end of beam-pipe, so that particles at very shallow angle are forced to
-  // create two cross-points, i.e. 1 hit point!
-  for (signed int i=-bp.getNSegments(); i<bp.getNSegments(); i++) {
+  bool foundHit = bp.checkTrackHits(m_matTrack.getOrigin(),direction,hitMaterialVec,hitPosVec);
 
-    float sgni = (i>=0) ? +1 : -1;
+  if (foundHit) {
 
-    double zi         = sgni*bp.zPos[abs(i)];
-    double zipls1     = sgni*bp.zPos[abs(i+1)];
-    double riLower    = bp.radiusLower[abs(i)];
-    double ripls1Lower= bp.radiusLower[abs(i+1)];
-    double riUpper    = bp.radiusUpper[abs(i)];
-    double ripls1Upper= bp.radiusUpper[abs(i+1)];
-    double tiltLower  = (sgni<0) ? -bp.getTiltLower(abs(i+1)) : +bp.getTiltLower(abs(i));
-    double tiltUpper  = (sgni<0) ? -bp.getTiltUpper(abs(i+1)) : +bp.getTiltUpper(abs(i));
+    for (unsigned int iHit=0; iHit<hitMaterialVec.size(); iHit++) {
 
-    double rPosLower = -1;
-    double rPosUpper = -1;
-    double zPosLower = -1;
-    double zPosUpper = -1;
-
-    // Tilt differen from +-pi/2 (@ pi/2 formulae based on zPos diverge)
-    if (zi!=zipls1) {
-
-      zPosUpper = (tan(theta)*z0 - tan(tiltUpper)*zi + riUpper)/(tan(theta) -tan(tiltUpper));
-      zPosLower = (tan(theta)*z0 - tan(tiltLower)*zi + riLower)/(tan(theta) -tan(tiltLower));
-
-      if ( ((zPosLower>=0) && (zPosLower>=zi) && (zPosLower<zipls1)) ||
-         ((zPosLower<0)  && (zPosLower<zi)  && (zPosLower>=zipls1)) ) rPosLower = tan(theta)*(zPosLower-z0);
-
-      if ( ((zPosUpper>=0) && (zPosUpper>=zi) && (zPosUpper<zipls1)) ||
-         ((zPosUpper<0)  && (zPosUpper<zi)  && (zPosUpper>=zipls1)) ) rPosUpper = tan(theta)*(zPosUpper-z0);
-    }
-    // Tilt = +-pi/2, formulae based on zPos diverge -> use different approach
-    else {
-
-      double rPos = tan(theta)*(zi-z0);
-
-      if ( (rPos>=MIN(riLower,ripls1Lower)) && (rPos<MAX(riLower,ripls1Lower)) ) {
-
-        zPosLower = zi;
-        rPosLower = rPos;
-      }
-      if ( (rPos>=MIN(riUpper,ripls1Upper)) && (rPos<MAX(riUpper,ripls1Upper)) ) {
-
-        zPosUpper = zi;
-        rPosUpper = rPos;
-      }
-    }
-
-    // Save individual points of crossings with beam-pipe contours
-    if (rPosLower!=-1 || rPosUpper!=-1) {
-
-      bpZRUpper.push_back(std::pair<double,double>(zPosUpper,rPosUpper));
-      bpZRLower.push_back(std::pair<double,double>(zPosLower,rPosLower));
-
-      // Material
-      //
-      // Positive z -> use directly index i to find material of corresponding segment
-      if (i>=0) bpRadIntLength.push_back(std::pair<double,double>(bp.radLength[i],bp.intLength[i]));
-      // Negative z -> use abs(i) -1 (indicis start at -(N-segments+1) and end-up at (-1) to find material of corresponding segment
-      else      bpRadIntLength.push_back(std::pair<double,double>(bp.radLength[abs(i)-1],bp.intLength[abs(i)-1]));
-    }
-  }
-
-  //
-  // Form hits from crossed points -> hit defined by average of two consecutive crossed points (maybe cross-points from lower & upper
-  // contours or lower only/upper only contours)
-  //
-  // Check that cross-points algorithm created points correctly first
-  if (bpZRLower.size()!=bpZRUpper.size()) {
-
-    std::ostringstream message;
-    message << "Beam-pipe algorithm assigning material not working correctly, check the code!";
-    throw PathfulException(message.str(), "VisitorMatBudget");
-  }
-  // Form hits
-  else {
-
-    for (unsigned int i=0; i<bpZRLower.size(); i++) {
-
-      double pathLength  = 0;
-      double rPosAvg     = 0;
-      double zPosAvg     = 0;
-      double radMaterial = -1;
-      double intMaterial = -1;
-
-      double zPosUpper = bpZRUpper[i].first;
-      double zPosLower = bpZRLower[i].first;
-      double rPosUpper = bpZRUpper[i].second;
-      double rPosLower = bpZRLower[i].second;
-      double radLength = bpRadIntLength[i].first;
-      double intLength = bpRadIntLength[i].second;
-
-      // Upper & Lower crossed
-      if (rPosLower!=-1 && rPosUpper!=-1) {
-
-        pathLength  = sqrt(pow(rPosUpper-rPosLower,2)+pow(zPosUpper-zPosLower,2));
-        rPosAvg     = (rPosUpper+rPosLower)/2.;
-        zPosAvg     = (zPosUpper+zPosLower)/2.;
-        radMaterial = pathLength/radLength;
-        intMaterial = pathLength/intLength;
-
-      }
-      // Upper or lower & next(next) upper or lower crossed -> update current point index by the found next(next) crossing point
-      else if ( (rPosLower==-1 && rPosUpper!=-1) || (rPosLower!=-1 && rPosUpper==-1)) {
-
-        // Look for next, next-next, next-next-next etc., set once found!
-        bool found = false;
-        while (!found) {
-
-          i++; // Get next point
-
-          if (i>=bpZRLower.size()) {
-            logERROR("BeamPipe not defined as a closed object, can't find all hit part!!!");
-            break;
-          }
-          else {
-
-            // Only one of these must be different from -1
-            double zPosUpperNext = bpZRUpper[i].first;
-            double zPosLowerNext = bpZRLower[i].first;
-            double rPosUpperNext = bpZRUpper[i].second;
-            double rPosLowerNext = bpZRLower[i].second;
-            double radLengthNext = bpRadIntLength[i].first;
-            double intLengthNext = bpRadIntLength[i].second;
-
-            // Different combinations may appear, but at least one of these: upper with upper or lower with upper or lower with lower
-            if      (rPosUpperNext!=-1 && rPosLowerNext!=-1) logERROR("Algorithmic problem when looking for material hits, check the code!!!");
-            else if (rPosUpperNext!=-1) {
-
-              if (rPosLower!=-1) {
-                pathLength = sqrt(pow(rPosUpperNext-rPosLower,2)+pow(zPosUpperNext-zPosLower,2));
-                rPosAvg    = (rPosUpperNext+rPosLower)/2.;
-                zPosAvg    = (zPosUpperNext+zPosLower)/2.;
-                found      = true;
-              }
-              else {
-                pathLength = sqrt(pow(rPosUpperNext-rPosUpper,2)+pow(zPosUpperNext-zPosUpper,2));
-                rPosAvg    = (rPosUpperNext+rPosUpper)/2.;
-                zPosAvg    = (zPosUpperNext+zPosUpper)/2.;
-                found      = true;
-              }
-            }
-            else if (rPosLowerNext!=-1) {
-
-              if (rPosLower!=-1) {
-                pathLength = sqrt(pow(rPosLowerNext-rPosLower,2)+pow(zPosLowerNext-zPosLower,2));
-                rPosAvg    = (rPosLowerNext+rPosLower)/2.;
-                zPosAvg    = (zPosLowerNext+zPosLower)/2.;
-                found      = true;
-              }
-              else {
-                pathLength = sqrt(pow(rPosLowerNext-rPosUpper,2)+pow(zPosLowerNext-zPosUpper,2));
-                rPosAvg    = (rPosLowerNext+rPosUpper)/2.;
-                zPosAvg    = (zPosLowerNext+zPosUpper)/2.;
-                found      = true;
-              }
-            }
-
-            // Check that material consistently defined: crossed-points forming the potential hit must be within the same material
-            if (radLength!=radLengthNext || intLength!=intLengthNext) {
-              logERROR("Algorithmic problem when looking for material hits: 2 crossed-points forming a potential hit not within the same material -> Check that Beam-pipe upper contour closing object & material definition!!!");
-            }
-            else {
-              radMaterial = pathLength/radLength;
-              intMaterial = pathLength/intLength;
-            }
-          }
-        } // While
-      }
-      else {
-
-        continue;
-      }
-
-      HitPtr hit(new Hit(rPosAvg, zPosAvg, nullptr, HitPassiveType::BeamPipe));
+      // Create corresponding hit
+      double rPos = hitPosVec[iHit]->Rho();
+      double zPos = hitPosVec[iHit]->Z();
 
       Material material;
-      material.radiation   = radMaterial;
-      material.interaction = intMaterial;
+      material.interaction = hitMaterialVec[iHit]->interaction;
+      material.radiation   = hitMaterialVec[iHit]->radiation;
 
+      HitPtr hit(new Hit(rPos, zPos, nullptr, HitPassiveType::BeamPipe));
       hit->setCorrectedMaterial(material);
       m_matTrack.addHit(std::move(hit));
 
-      // Fill mat. budget container
+      // Update material map
       m_matBudget["Beampipe"].radiation   += material.radiation;
       m_matBudget["Beampipe"].interaction += material.interaction;
 
-    } // For
-
-  } // Form hits algorithm
+      // Clear memory from temporary vectors
+      delete hitPosVec[iHit];
+      hitPosVec[iHit] = nullptr;
+      delete hitMaterialVec[iHit];
+      hitMaterialVec[iHit] = nullptr;
+    }
+  }
 }
 
 //

--- a/source/Geometry/include/BeamPipe.h
+++ b/source/Geometry/include/BeamPipe.h
@@ -8,8 +8,10 @@
 #ifndef BEAMPIPE_H_
 #define BEAMPIPE_H_
 
+#include <vector>
 #include <memory>
 
+#include <Math/Vector3Dfwd.h>
 #include "Property.h"
 #include "Visitable.h"
 
@@ -17,10 +19,12 @@
 class ConstGeometryVisitor;
 class GeometryVisitor;
 class InactiveTube;
-
+class RILength;
 /*
  * @class BeamPipe
- * @details Geometry & material object holding information about the beam pipe. Beam-pipe is defined by 2 contours: upper (@ higher R) & lower (@ lower R).
+ * @details Geometry & material object holding information about the beam pipe. Beam-pipe geometry depends on the SimParms.use3DBeamPipe() variable:
+ *
+ * 1) If true, then the beam-pipe shape is modelled as 3D (phi-symmetric) and is defined by 2 contours in N segments: upper (@ higher R) & lower (@ lower R).
  * Both contours are defined by a sequence of [z,r] points, R-Phi symmetry is being assumed. The beam-pipe shape is then defined by 2 lines connecting these
  * points. In order to enclose the object and form thus a 3D object for material & tracking purposes, the upper line is assumed to end-up at the same [z,r]
  * point as the lower line. If the beam-pipe consists of several parts being constructed from different materials, e.g. Berrylium and Aluminium, the upper
@@ -38,6 +42,12 @@ class InactiveTube;
  * Finally, material is defined for each line segment, i.e. number of defined segments is (N-1), where N is number of [z,r] points. Tilt of each segment is
  * automatically calculated from [z,r] positions of individual upper/lower contour points, so no input from that point of view is needed.
  *
+ * 2) If false, then the beam-pipe is modelled only as 2D (phi symmetric) and thus defined only by 1 contour in N segments. Material is assibned similarly.
+ *
+ *                             ---------------
+ *                            /
+ * --------------------------/
+ *         Be               |Al|      Al
  */
 class BeamPipe : public PropertyObject, public Identifiable<string>, public Buildable, Visitable {
 
@@ -55,14 +65,32 @@ class BeamPipe : public PropertyObject, public Identifiable<string>, public Buil
   //! Setup: link lambda functions to various beampipe related properties (use setup functions for ReadOnly Computable properties -> use UncachedComputable if everytime needs to be recalculated)
   void setup();
 
+  //! Check if track hit the beam-pipe -> if yes, return true with passed material & hit position vector (several hits may be created if beam-pipe e.g. tilted & luminous region of non-zero sigma)
+  bool checkTrackHits(const ROOT::Math::XYZVector& trackOrig,
+                      const ROOT::Math::XYZVector& trackDir,
+                      std::vector<RILength*>& hitMaterialVec,
+                      std::vector<ROOT::Math::RhoZPhiVector*>& hitPosVec) const;
+
   //! Get number of defined beam-pipe segments
   double getNSegments() const { return zPos.size()-1;};
+
+  //! Get radius of upper wall (contour) of i-th segment
+  double getRadiusUpper(unsigned int i) const;
+
+  //! Get radius of lower wall (contour) of i-th segment
+  double getRadiusLower(unsigned int i) const;
+
+  //! Get average radius
+  double getAvgRadius(unsigned int i) const { return (getRadiusUpper(i)+getRadiusLower(i))/2.; };
 
   //! Get tilt of upper wall (contour) of i-th segment
   double getTiltUpper(unsigned int i) const;
 
   //! Get tilt of lower wall (contour) of i-th segment
   double getTiltLower(unsigned int i) const;
+
+  //! Get averega tilt of i-th segment
+  double getAvgTilt(unsigned int i) const { return (getTiltUpper(i)+getTiltLower(i))/2.; };
 
   //! Get average thickness of i-th segment
   double getAvgThickness(unsigned int i) const;
@@ -74,15 +102,19 @@ class BeamPipe : public PropertyObject, public Identifiable<string>, public Buil
   void accept(ConstGeometryVisitor& v) const;
 
   // Beam pipe radius, thickness, thickness in rad. length, in int. length
-  ReadonlyPropertyVector<double>      radiusLower;      //!< Beam pipe radii: lower wall/contour (beam-pipe shape described by sequence of segments defined by: lower & upper radii & zPos )
-  ReadonlyPropertyVector<double>      radiusUpper;      //!< Beam pipe radii: upper wall/contour (beam-pipe shape described by sequence of segments defined by: lower & upper radii & zPos )
   ReadonlyPropertyVector<double>      zPos;             //!< Beam pipe zPos  (beam-pipe shape described by sequence of segments defined by: low & high radii & zPos )
   ReadonlyProperty<double, Computable>minRadius;        //!< Beam pipe minimal radius -> used e.g. for drawing purposes
   ReadonlyProperty<double, Computable>maxRadius;        //!< Beam pipe maximum radius -> used e.g. for drawing purposes
-  ReadonlyPropertyVector<double>      radLength;        //!< Beam pipe material rad. length for each beam-pipe segment -> material calculated as: pathLength in given segment/radLength
-  ReadonlyPropertyVector<double>      intLength;        //!< Beam pipe material int. lenght for each beam-pipe segment -> material calculated as: pathLength in given segment/radLength
+  ReadonlyPropertyVector<double>      radLength;        //!< Beam pipe material rad. length for each beam-pipe segment -> material calculated as: pathLength in given segment/radLength for 3D, but thickness/tan(angle) for 2D
+  ReadonlyPropertyVector<double>      intLength;        //!< Beam pipe material int. lenght for each beam-pipe segment -> material calculated as: pathLength in given segment/radLength for 3D, but thickness/tan(angle) for 2D
 
  private:
+
+  // Keep the variables private as their value is different if 3D or 2D implementation used
+  ReadonlyPropertyVector<double>      radiusLower;      //!< Beam pipe radii: lower wall/contour (3D) (beam-pipe shape described by sequence of segments defined by: lower & upper radii & zPos )
+  ReadonlyPropertyVector<double>      radiusUpper;      //!< Beam pipe radii: upper wall/contour (3D) (beam-pipe shape described by sequence of segments defined by: lower & upper radii & zPos )
+  ReadonlyPropertyVector<double>      radius;           //!< Beam pipe avg radius: 2D approximation only
+  ReadonlyPropertyVector<double>      thickness;        //!< Beam pipe thickness for each segment (N radii points -1): 2D approximation only
 
   //! Cross-check parameters provided from geometry configuration file
   void check() override;

--- a/source/Geometry/src/BeamPipe.cc
+++ b/source/Geometry/src/BeamPipe.cc
@@ -1,5 +1,5 @@
 /*
- * BeamPipe.cc
+ *  BeamPipe.cc
  *
  *  Created on: 11. 5. 2016
  *      Author: drasal
@@ -8,7 +8,12 @@
 #include "BeamPipe.h"
 
 #include "math_functions.h"
+
+#include "Math/DisplacementVector3D.h"
+#include "Math/Cylindrical3D.h"
 #include "InactiveTube.h"
+#include "MessageLogger.h"
+#include "SimParms.h"
 #include "Visitor.h"
 
 //
@@ -17,11 +22,13 @@
 BeamPipe::BeamPipe(const PropertyTree& treeProperty) :
  radiusUpper(     "radiusUpper", parsedOnly()),
  radiusLower(     "radiusLower", parsedOnly()),
+ radius(          "radius"     , parsedOnly()),
+ thickness(       "thickness"  , parsedOnly()),
  minRadius(string("minRadius")),
  maxRadius(string("maxRAdius")),
- zPos(            "zPos"     , parsedOnly()),
- radLength(       "radLength", parsedOnly()),
- intLength(       "intLength", parsedOnly())
+ zPos(            "zPos"       , parsedOnly()),
+ radLength(       "radLength"  , parsedOnly()),
+ intLength(       "intLength"  , parsedOnly())
 {
   // Set the geometry config parameters
   this->myid(treeProperty.data());
@@ -65,21 +72,53 @@ void BeamPipe::check() {
 
   PropertyObject::check();
 
-  // Check that number of defined beam-pipe segments the same in radius & Z-length
-  if (radiusLower.size()!=zPos.size()) {
-    throw PathfulException("Number of defined beam-pipe segments not the same in lower radius & z position!","BeamPipe");
+  // Check for beam-pipe defined in 3D version
+  if (SimParms::getInstance().use3DBeamPipe()) {
+
+    if (radiusLower.size()<2) {
+
+      std::ostringstream message;
+      message << "Number of defined beam-pipe points for lower contour " << radiusLower.size() << " must be at least 2 in order to define at least 1 segment.";
+      message << " Check whether not defining radius only for 2DBeamPipe, but assuming 3DBeamPipe in SimParms config file!";
+
+      throw PathfulException(message.str(),"BeamPipe3D");
+    }
+    if (radiusLower.size()!=zPos.size()) {
+      throw PathfulException("Number of defined beam-pipe segments not the same in lower radius & z position!","BeamPipe3D");
+    }
+    if (radiusUpper.size()!=zPos.size()) {
+      throw PathfulException("Number of defined beam-pipe segments not the same in  radius & z position!","BeamPipe3D");
+    }
+    if (radLength.size()!=(zPos.size()-1)) {
+      throw PathfulException("Number of defined rad. length parameters must equal to number of segments, i.e. number of radii/zpos points minus one!","BeamPipe3D");
+    }
+    if (intLength.size()!=(zPos.size()-1)) {
+      throw PathfulException("Number of defined int. length parameters must equal to number of segments, i.e. number of radii/zpos points minus one!","BeamPipe3D");
+    }
   }
-  if (radiusUpper.size()!=zPos.size()) {
-    throw PathfulException("Number of defined beam-pipe segments not the same in  radius & z position!","BeamPipe");
-  }
-  if (radiusLower.size()<2) {
-    throw PathfulException("Number of defined beam-pipe points must be at least 2 in order to define at least 1 segment!","BeamPipe");
-  }
-  if (radLength.size()!=(zPos.size()-1)) {
-    throw PathfulException("Number of defined rad. length parameters must equal to number of segments, i.e. number of radii/zpos points minus one!","BeamPipe");
-  }
-  if (intLength.size()!=(zPos.size()-1)) {
-    throw PathfulException("Number of defined int. length parameters must equal to number of segments, i.e. number of radii/zpos points minus one!","BeamPipe");
+  // otherwise 2D version expected
+  else {
+
+    if (radius.size()<2) {
+
+      std::ostringstream message;
+      message << "Number of defined beam-pipe points " << radius.size() << " must be at least 2 in order to define at least 1 segment.";
+      message << " Check whether not defining lower & upper radius for 3DBeamPipe, but assuming 2DBeamPipe in SimParms config file!";
+
+      throw PathfulException(message.str(),"BeamPipe2D");
+    }
+    if (radius.size()!=zPos.size()) {
+      throw PathfulException("Number of defined beam-pipe segments not the same in radius & z position!","BeamPipe2D");
+    }
+    if (thickness.size()!=(zPos.size()-1)) {
+      throw PathfulException("Number of thickness parameters must equal to number of segments, i.e. number of radii/zpos points minus one!","BeamPipe2D");
+    }
+    if (radLength.size()!=(zPos.size()-1)) {
+      throw PathfulException("Number of defined rad. length parameters must equal to number of segments, i.e. number of radii/zpos points minus one!","BeamPipe2D");
+    }
+    if (intLength.size()!=(zPos.size()-1)) {
+      throw PathfulException("Number of defined int. length parameters must equal to number of segments, i.e. number of radii/zpos points minus one!","BeamPipe2D");
+    }
   }
 }
 
@@ -88,8 +127,366 @@ void BeamPipe::check() {
 //
 void BeamPipe::setup() {
 
-  maxRadius.setup([&]() { double max = 0;                                  for (unsigned int i=0; i<radiusUpper.size(); i++) { max = MAX(max, radiusUpper[i]); } return max; });
-  minRadius.setup([&]() { double min = std::numeric_limits<double>::max(); for (unsigned int i=0; i<radiusLower.size(); i++) { min = MIN(min, radiusLower[i]); } return min; });;
+  maxRadius.setup([&]() { double max = 0;
+
+    if (SimParms::getInstance().use3DBeamPipe()) { for (unsigned int i=0; i<radiusUpper.size(); i++) { max = MAX(max, radiusUpper[i]); };}
+    else                                         { for (unsigned int i=0; i<radius.size(); i++)      { max = MAX(max, radius[i]); }; }
+    return max; });
+  minRadius.setup([&]() { double min = std::numeric_limits<double>::max();
+
+    if (!SimParms::getInstance().use3DBeamPipe()){ for (unsigned int i=0; i<radiusLower.size(); i++) { min = MIN(min, radiusLower[i]); };}
+    else                                         { for (unsigned int i=0; i<radius.size(); i++)      { min = MIN(min, radius[i]); }; }
+    return min; });
+}
+
+//
+// Check if track hit the beam-pipe -> if yes, return true with passed material & hit position vector
+//
+bool BeamPipe::checkTrackHits(const ROOT::Math::XYZVector& trackOrig, const ROOT::Math::XYZVector& trackDir, std::vector<RILength*>& hitMaterialVec, std::vector<ROOT::Math::RhoZPhiVector*>& hitPosVec) const {
+
+  // Hit containers
+  Material*                  hitMaterial = nullptr;
+  ROOT::Math::RhoZPhiVector* hitPos      = nullptr;
+
+  // Found at least one hit?
+  bool   hitFound = false;
+
+  // Track parameters
+  double theta    = trackDir.Theta();
+  double z0       = trackOrig.Z();
+
+  //
+  // Beam-pipe defined approximatively as a 2D object only (phi-symmetric object with thickness  projected)
+  if (!SimParms::getInstance().use3DBeamPipe()) {
+
+    // Check all segments in positive part of the beam-pipe
+    for (unsigned int i=0; i<getNSegments(); i++) {
+
+      // Initialize
+      hitMaterial = nullptr;
+      hitPos      = nullptr;
+
+      double zi       = zPos[i];
+      double zipls1   = zPos[i+1];
+      double ri       = radius[i];
+      double tilt     = getAvgTilt(i);
+      double thickness= getAvgThickness(i);
+
+      double zPos = (tan(theta)*z0 - tan(tilt)*zi + ri)/(tan(theta) -tan(tilt));
+
+      if ( ((zPos>=0) && (zPos>=zi) && (zPos<zipls1)) ||
+           ((zPos<0)  && (zPos<zi)  && (zPos>=zipls1)) ) {
+
+        double rPos = tan(theta)*(zPos-z0);
+
+        hitMaterial = new Material();
+        hitMaterial->radiation   = thickness/radLength(i)/fabs(sin(theta-tilt));
+        hitMaterial->interaction = thickness/intLength(i)/fabs(sin(theta-tilt));
+
+        hitPos = new ROOT::Math::RhoZPhiVector();
+        hitPos->SetZ(zPos);
+        hitPos->SetRho(rPos);
+        hitPos->SetPhi(0); // Assumed phi symmetry, why not e.g. phi=0 for completness
+
+        hitMaterialVec.push_back(hitMaterial);
+        hitPosVec.push_back(hitPos);
+
+        hitFound = true;
+      }
+    }
+
+    // Check all segments in negative part of the beam-pipe
+    for (unsigned int i=0; i<getNSegments(); i++) {
+
+      // Initialize
+      hitMaterial = nullptr;
+      hitPos      = nullptr;
+
+      double zi       = -zPos[i];
+      double zipls1   = -zPos[i+1];
+      double ri       = +radius[i];
+      double tilt     = -getAvgTilt(i);
+      double thickness= +getAvgThickness(i);
+
+      double zPos = (tan(theta)*z0 - tan(tilt)*zi + ri)/(tan(theta) -tan(tilt));
+
+      if ( ((zPos>=0) && (zPos>=zi) && (zPos<zipls1)) ||
+           ((zPos<0)  && (zPos<zi)  && (zPos>=zipls1)) ) {
+
+        double rPos = tan(theta)*(zPos-z0);
+
+        hitMaterial = new Material();
+        hitMaterial->radiation   = thickness/radLength(i)/fabs(sin(theta-tilt));
+        hitMaterial->interaction = thickness/intLength(i)/fabs(sin(theta-tilt));
+
+        hitPos = new ROOT::Math::RhoZPhiVector();
+        hitPos->SetZ(zPos);
+        hitPos->SetRho(rPos);
+        hitPos->SetPhi(0); // Assumed phi symmetry, why not e.g. phi=0 for completness
+
+        hitMaterialVec.push_back(hitMaterial);
+        hitPosVec.push_back(hitPos);
+
+        hitFound = true;
+      }
+    }
+  } // If beam-pipe defined approximately like 2D object
+
+  //
+  // Beam-pipe defined as a 3D object: phi-symmetric object defined by 2 contours upper & lower, 2 contours being defined by a sequence of points
+  else {
+
+    // Eta assumed to be positive so, theta between 0-90deg, hence material is always given as firstUpper-firstLower hit, secondUpper-secondLower etc. -> sort from lowest to highest Z
+    std::vector<std::pair<double,double>> bpZRLower;
+    std::vector<std::pair<double,double>> bpZRUpper;
+    std::vector<std::pair<double,double>> bpRadIntLength;
+
+    // Check all segments from negative to positive part of the beam-pipe & create crossing points with beam-pipe contours (lower & upper)
+    // Upper contour is asssumed to close-up the beam-pipe segments containing a certain material, e.g. beam-pipe constructed from central Be & aluminium flanges
+    // If beam-pipe consists of 1 material only, the upper contour will close-up just the end of beam-pipe, so that particles at very shallow angle are forced to
+    // create two cross-points, i.e. 1 hit point!
+    for (signed int i=-getNSegments(); i<getNSegments(); i++) {
+
+      // Initialize
+      hitMaterial = nullptr;
+      hitPos      = nullptr;
+
+      float sgni = (i>=0) ? +1 : -1;
+
+      double zi         = sgni*zPos[abs(i)];
+      double zipls1     = sgni*zPos[abs(i+1)];
+      double riLower    = radiusLower[abs(i)];
+      double ripls1Lower= radiusLower[abs(i+1)];
+      double riUpper    = radiusUpper[abs(i)];
+      double ripls1Upper= radiusUpper[abs(i+1)];
+      double tiltLower  = (sgni<0) ? -getTiltLower(abs(i+1)) : +getTiltLower(abs(i));
+      double tiltUpper  = (sgni<0) ? -getTiltUpper(abs(i+1)) : +getTiltUpper(abs(i));
+
+      double rPosLower = -1;
+      double rPosUpper = -1;
+      double zPosLower = -1;
+      double zPosUpper = -1;
+
+      // Tilt differen from +-pi/2 (@ pi/2 formulae based on zPos diverge)
+      if (zi!=zipls1) {
+
+        zPosUpper = (tan(theta)*z0 - tan(tiltUpper)*zi + riUpper)/(tan(theta) -tan(tiltUpper));
+        zPosLower = (tan(theta)*z0 - tan(tiltLower)*zi + riLower)/(tan(theta) -tan(tiltLower));
+
+        if ( ((zPosLower>=0) && (zPosLower>=zi) && (zPosLower<zipls1)) ||
+           ((zPosLower<0)  && (zPosLower<zi)  && (zPosLower>=zipls1)) ) rPosLower = tan(theta)*(zPosLower-z0);
+
+        if ( ((zPosUpper>=0) && (zPosUpper>=zi) && (zPosUpper<zipls1)) ||
+           ((zPosUpper<0)  && (zPosUpper<zi)  && (zPosUpper>=zipls1)) ) rPosUpper = tan(theta)*(zPosUpper-z0);
+      }
+      // Tilt = +-pi/2, formulae based on zPos diverge -> use different approach
+      else {
+
+        double rPos = tan(theta)*(zi-z0);
+
+        if ( (rPos>=MIN(riLower,ripls1Lower)) && (rPos<MAX(riLower,ripls1Lower)) ) {
+
+          zPosLower = zi;
+          rPosLower = rPos;
+        }
+        if ( (rPos>=MIN(riUpper,ripls1Upper)) && (rPos<MAX(riUpper,ripls1Upper)) ) {
+
+          zPosUpper = zi;
+          rPosUpper = rPos;
+        }
+      }
+
+      // Save individual points of crossings with beam-pipe contours
+      if (rPosLower!=-1 || rPosUpper!=-1) {
+
+        bpZRUpper.push_back(std::pair<double,double>(zPosUpper,rPosUpper));
+        bpZRLower.push_back(std::pair<double,double>(zPosLower,rPosLower));
+
+        // Material
+        //
+        // Positive z -> use directly index i to find material of corresponding segment
+        if (i>=0) bpRadIntLength.push_back(std::pair<double,double>(radLength[i],intLength[i]));
+        // Negative z -> use abs(i) -1 (indicis start at -(N-segments+1) and end-up at (-1) to find material of corresponding segment
+        else      bpRadIntLength.push_back(std::pair<double,double>(radLength[abs(i)-1],intLength[abs(i)-1]));
+      }
+    }
+
+    //
+    // Form hits from crossed points -> hit defined by average of two consecutive crossed points (maybe cross-points from lower & upper
+    // contours or lower only/upper only contours)
+    //
+    // Check that cross-points algorithm created points correctly first
+    if (bpZRLower.size()!=bpZRUpper.size()) {
+
+      std::ostringstream message;
+      message << "Beam-pipe algorithm assigning material not working correctly, check the code!";
+      throw PathfulException(message.str(), "VisitorMatBudget");
+    }
+    // Form hits
+    else {
+
+      for (unsigned int i=0; i<bpZRLower.size(); i++) {
+
+        double pathLength  = 0;
+        double rPosAvg     = 0;
+        double zPosAvg     = 0;
+        double radMaterial = -1;
+        double intMaterial = -1;
+
+        double zPosUpper = bpZRUpper[i].first;
+        double zPosLower = bpZRLower[i].first;
+        double rPosUpper = bpZRUpper[i].second;
+        double rPosLower = bpZRLower[i].second;
+        double radLength = bpRadIntLength[i].first;
+        double intLength = bpRadIntLength[i].second;
+
+        // Upper & Lower crossed
+        if (rPosLower!=-1 && rPosUpper!=-1) {
+
+          pathLength  = sqrt(pow(rPosUpper-rPosLower,2)+pow(zPosUpper-zPosLower,2));
+          rPosAvg     = (rPosUpper+rPosLower)/2.;
+          zPosAvg     = (zPosUpper+zPosLower)/2.;
+          radMaterial = pathLength/radLength;
+          intMaterial = pathLength/intLength;
+
+        }
+        // Upper or lower & next(next) upper or lower crossed -> update current point index by the found next(next) crossing point
+        else if ( (rPosLower==-1 && rPosUpper!=-1) || (rPosLower!=-1 && rPosUpper==-1)) {
+
+          // Look for next, next-next, next-next-next etc., set once found!
+          bool found = false;
+          while (!found) {
+
+            i++; // Get next point
+
+            if (i>=bpZRLower.size()) {
+              logERROR("BeamPipe not defined as a closed object, can't find all hit part!!!");
+              break;
+            }
+            else {
+
+              // Only one of these must be different from -1
+              double zPosUpperNext = bpZRUpper[i].first;
+              double zPosLowerNext = bpZRLower[i].first;
+              double rPosUpperNext = bpZRUpper[i].second;
+              double rPosLowerNext = bpZRLower[i].second;
+              double radLengthNext = bpRadIntLength[i].first;
+              double intLengthNext = bpRadIntLength[i].second;
+
+              // Different combinations may appear, but at least one of these: upper with upper or lower with upper or lower with lower
+              if      (rPosUpperNext!=-1 && rPosLowerNext!=-1) logERROR("Algorithmic problem when looking for material hits, check the code!!!");
+              else if (rPosUpperNext!=-1) {
+
+                if (rPosLower!=-1) {
+                  pathLength = sqrt(pow(rPosUpperNext-rPosLower,2)+pow(zPosUpperNext-zPosLower,2));
+                  rPosAvg    = (rPosUpperNext+rPosLower)/2.;
+                  zPosAvg    = (zPosUpperNext+zPosLower)/2.;
+                  found      = true;
+                }
+                else {
+                  pathLength = sqrt(pow(rPosUpperNext-rPosUpper,2)+pow(zPosUpperNext-zPosUpper,2));
+                  rPosAvg    = (rPosUpperNext+rPosUpper)/2.;
+                  zPosAvg    = (zPosUpperNext+zPosUpper)/2.;
+                  found      = true;
+                }
+              }
+              else if (rPosLowerNext!=-1) {
+
+                if (rPosLower!=-1) {
+                  pathLength = sqrt(pow(rPosLowerNext-rPosLower,2)+pow(zPosLowerNext-zPosLower,2));
+                  rPosAvg    = (rPosLowerNext+rPosLower)/2.;
+                  zPosAvg    = (zPosLowerNext+zPosLower)/2.;
+                  found      = true;
+                }
+                else {
+                  pathLength = sqrt(pow(rPosLowerNext-rPosUpper,2)+pow(zPosLowerNext-zPosUpper,2));
+                  rPosAvg    = (rPosLowerNext+rPosUpper)/2.;
+                  zPosAvg    = (zPosLowerNext+zPosUpper)/2.;
+                  found      = true;
+                }
+              }
+
+              // Check that material consistently defined: crossed-points forming the potential hit must be within the same material
+              if (radLength!=radLengthNext || intLength!=intLengthNext) {
+                logERROR("Algorithmic problem when looking for material hits: 2 crossed-points forming a potential hit not within the same material -> Check that Beam-pipe upper contour closing object & material definition!!!");
+              }
+              else {
+                radMaterial = pathLength/radLength;
+                intMaterial = pathLength/intLength;
+              }
+            }
+          } // While
+        }
+        else {
+
+          continue;
+        }
+
+        hitMaterial = new Material();
+        hitMaterial->radiation   = radMaterial;
+        hitMaterial->interaction = intMaterial;
+
+        hitPos = new ROOT::Math::RhoZPhiVector();
+        hitPos->SetZ(zPosAvg);
+        hitPos->SetRho(rPosAvg);
+        hitPos->SetPhi(0); // Assumed phi symmetry, why not e.g. phi=0 for completness
+
+        hitMaterialVec.push_back(hitMaterial);
+        hitPosVec.push_back(hitPos);
+
+        hitFound = true;
+      } // For
+    } // Form hits algorithm
+
+  } // If/Else 2D/3D beam-pipe geometry
+
+  return hitFound;
+}
+
+//
+// Get radius of upper wall (contour) of i-th segment
+//
+double BeamPipe::getRadiusUpper(unsigned int i) const {
+
+  double radiusValue = -1;
+
+  if (i>getNSegments()) {
+
+    std::ostringstream message;
+    message << "Upper radius not defined for beam-pipe countour point i=" << i;
+    throw PathfulException(message.str(), "BeamPipe");
+  }
+  else {
+
+    // 3D version of beam-pipe geometry
+    if (SimParms::getInstance().use3DBeamPipe()) radiusValue = radiusUpper[i];
+    else                                         radiusValue = radius[i];
+  }
+
+  return radiusValue;
+}
+
+//
+// Get radius of lower wall (contour) of i-th segment
+//
+double BeamPipe::getRadiusLower(unsigned int i) const {
+
+  double radiusValue = -1;
+
+  if (i>getNSegments()) {
+
+    std::ostringstream message;
+    message << "Lower radius not defined for beam-pipe countour point i=" << i;
+    throw PathfulException(message.str(), "BeamPipe");
+  }
+  else {
+
+    // 3D version of beam-pipe geometry
+    if (SimParms::getInstance().use3DBeamPipe()) radiusValue = radiusLower[i];
+    else                                         radiusValue = radius[i];
+  }
+
+  return radiusValue;
 }
 
 //
@@ -107,11 +504,23 @@ double BeamPipe::getTiltUpper(unsigned int i) const {
   }
   else {
 
-    double radiusIPls1 = radiusUpper[i+1];
-    double radiusI     = radiusUpper[i]  ;
+    // 3D version of beam-pipe geometry
+    if (SimParms::getInstance().use3DBeamPipe()) {
+      double radiusIPls1 = radiusUpper[i+1];
+      double radiusI     = radiusUpper[i]  ;
 
-    if (radiusIPls1==radiusI) tiltAngle = 0;
-    else                      tiltAngle = atan((radiusIPls1-radiusI)/(zPos[i+1]-zPos[i]));
+      if (radiusIPls1==radiusI) tiltAngle = 0;
+      else                      tiltAngle = atan((radiusIPls1-radiusI)/(zPos[i+1]-zPos[i]));
+    }
+    // Simplified 2D version of beam-pipe
+    else {
+
+      double radiusIPls1 = radius[i+1];
+      double radiusI     = radius[i]  ;
+
+      if (radiusIPls1==radiusI) tiltAngle = 0;
+      else                      tiltAngle = atan((radiusIPls1-radiusI)/(zPos[i+1]-zPos[i]));
+    }
   }
 
   return tiltAngle;
@@ -132,11 +541,23 @@ double BeamPipe::getTiltLower(unsigned int i) const {
   }
   else {
 
-    double radiusIPls1 = radiusLower[i+1];
-    double radiusI     = radiusLower[i]  ;
+    // 3D version of beam-pipe geometry
+    if (SimParms::getInstance().use3DBeamPipe()) {
+      double radiusIPls1 = radiusLower[i+1];
+      double radiusI     = radiusLower[i]  ;
 
-    if (radiusIPls1==radiusI) tiltAngle = 0;
-    else                      tiltAngle = atan((radiusIPls1-radiusI)/(zPos[i+1]-zPos[i]));
+      if (radiusIPls1==radiusI) tiltAngle = 0;
+      else                      tiltAngle = atan((radiusIPls1-radiusI)/(zPos[i+1]-zPos[i]));
+    }
+    // Simplified 2D version of beam-pipe
+    else {
+
+      double radiusIPls1 = radius[i+1];
+      double radiusI     = radius[i]  ;
+
+      if (radiusIPls1==radiusI) tiltAngle = 0;
+      else                      tiltAngle = atan((radiusIPls1-radiusI)/(zPos[i+1]-zPos[i]));
+    }
   }
 
   return tiltAngle;
@@ -147,7 +568,7 @@ double BeamPipe::getTiltLower(unsigned int i) const {
 //
 double BeamPipe::getAvgThickness(unsigned int i) const {
 
-  double thickness = -1;
+  double avgThickness = -1;
 
   if (i>=getNSegments()) {
 
@@ -157,10 +578,11 @@ double BeamPipe::getAvgThickness(unsigned int i) const {
   }
   else {
 
-    thickness = (radiusUpper[i]+radiusUpper[i+1]-radiusLower[i]-radiusLower[i+1])/2;
+    if (SimParms::getInstance().use3DBeamPipe()) avgThickness = (radiusUpper[i]+radiusUpper[i+1]-radiusLower[i]-radiusLower[i+1])/2;
+    else                                         avgThickness = thickness[i];
   }
 
-  return thickness;
+  return avgThickness;
 }
 
 

--- a/source/Tools/include/PlotDrawer.h
+++ b/source/Tools/include/PlotDrawer.h
@@ -224,8 +224,8 @@ struct RZ : public std::pair<int, int>, private Rounder {
 //! Get module RZ (R=>0, Z full) coordinates rounded with micron precision
 struct RZFull : public RZ {
   const bool valid;
-  RZFull(const DetectorModule& m) : RZ(m), valid(true) {}
-  RZFull(const XYZVector& v) : RZ(v), valid(true) {}
+  RZFull(const DetectorModule& m) : RZ(m), valid(true) {} //(m.center().Z() >= 0)
+  RZFull(const XYZVector& v)      : RZ(v), valid(true) {} //(v.Z() >= 0) {}
 };
 
 //! Based on module coordinate type <XY>, <RZ>, <RZFull> get module parameters: x,y ; r,z(>=0) ; r,z -> module expressed as PolyLine

--- a/source/Tools/include/SimParms.h
+++ b/source/Tools/include/SimParms.h
@@ -113,6 +113,7 @@ class SimParms : public PropertyObject, public Buildable, public Visitable {
   ReadonlyProperty<bool  , Default>   useLumiRegInAnalysis; //!< Apply luminous region constraints, when analysing geometry (resolution, pattern reco, etc.)
   ReadonlyProperty<bool  , NoDefault> useIPConstraint;      //!< Use IP constraint in track fitting
   ReadonlyProperty<bool  , Default>   useParabolicApprox;   //!< Use parabolic approximation in tracking & track propagation (for consistency reasons)
+  ReadonlyProperty<bool  , Default>   use3DBeamPipe;        //!< Define a beam-pipe by 2 contours inner & outer (phi-symmetric) to model 3D shape of beam-pipe or use only a simple 2D shape, defined by 1 countour (phi symmetric)
   ReadonlyProperty<int   , NoDefault> ptCost;
   ReadonlyProperty<int   , NoDefault> stripCost;
   ReadonlyProperty<double, NoDefault> efficiency;

--- a/source/Tools/src/SimParms.cc
+++ b/source/Tools/src/SimParms.cc
@@ -26,6 +26,7 @@ SimParms::SimParms() :
  useLumiRegInGeomBuild(   "useLumiRegInGeomBuild"   , parsedOnly(), 1),
  useLumiRegInAnalysis(    "useLumiRegInAnalysis"    , parsedOnly(), 0),
  useParabolicApprox(      "useParabolicApprox"      , parsedOnly(), 0),
+ use3DBeamPipe(           "use3DBeamPipe"           , parsedOnly(), 0),
  ptCost(                  "ptCost"                  , parsedAndChecked()),
  stripCost(               "stripCost"               , parsedAndChecked()),
  efficiency(              "efficiency"              , parsedAndChecked()),
@@ -75,8 +76,6 @@ SimParms::SimParms() :
     irradiationMapFiles.appendString(path);
     m_irradiationMapsManager->addIrradiationMap(path.c_str());
   }
-  
- 
 }
 
 //

--- a/source/Tracking/include/Track.h
+++ b/source/Tracking/include/Track.h
@@ -254,7 +254,7 @@ protected:
   //! Sort internally all hits assigned to this track -> sorting algorithm based on hit radius - by smaller radius sooner or vice-versa (inner-to-outer approach or vice-versa)
   void sortHits(bool bySmallerR);
 
-  //! Remove hits, which would be at radius higher than f*curling_radius (hits assumed to be found in line approach, which is perfectly valid if the geometry has a cylindrical
+  //! Remove hits, which would be at radius higher than curling_radius (hits assumed to be found in line approach, which is perfectly valid if the geometry has a cylindrical
   //! symmetry, but then all hits above curling radius must be removed -> check that hits are below curling radius). Factor f stands for a cut_off factor to avoid passage of
   //! modules at very shallow angle, i.e. hit radius close to the curling_radius: defined by max sin(phi-phi0), where phi is set as follows: arc_length = R*2*phi
   bool isHitRPosLowerThanCurlingRadius(double rPos, double zPos) { return rPos<track_maxSinPhi*2*getRadius(zPos); }

--- a/source/Tracking/src/VisitorMatTrack.cc
+++ b/source/Tracking/src/VisitorMatTrack.cc
@@ -45,204 +45,37 @@ VisitorMatTrack::~VisitorMatTrack()
 void VisitorMatTrack::visit(const BeamPipe& bp)
 {
   //
-  // Add hit corresponding with beam-pipe
-  double theta = m_matTrack.getTheta();
-  //double eta   = m_matTrack.getEta();
-  double z0    = m_matTrack.getOrigin().Z();
+  // Add hits created within the beam-pipe (may be several hits if beam-pipe tilted & luminous region of non-zero sigma)
+  XYZVector  direction(m_matTrack.getDirection());
 
-  // Eta assumed to be positive so, theta between 0-90deg, hence material is always given as firstUpper-firstLower hit, secondUpper-secondLower etc. -> sort from lowest to highest Z
-  std::vector<std::pair<double,double>> bpZRLower;
-  std::vector<std::pair<double,double>> bpZRUpper;
-  std::vector<std::pair<double,double>> bpRadIntLength;
+  std::vector<Material*>                  hitMaterialVec;
+  std::vector<ROOT::Math::RhoZPhiVector*> hitPosVec;
 
-  // Check all segments from negative to positive part of the beam-pipe & create crossing points with beam-pipe contours (lower & upper)
-  // Upper contour is asssumed to close-up the beam-pipe segments containing a certain material, e.g. beam-pipe constructed from central Be & aluminium flanges
-  // If beam-pipe consists of 1 material only, the upper contour will close-up just the end of beam-pipe, so that particles at very shallow angle are forced to
-  // create two cross-points, i.e. 1 hit point!
-  for (signed int i=-bp.getNSegments(); i<bp.getNSegments(); i++) {
+  bool foundHit = bp.checkTrackHits(m_matTrack.getOrigin(),direction,hitMaterialVec,hitPosVec);
 
-    float sgni = (i>=0) ? +1 : -1;
+  if (foundHit) {
 
-    double zi         = sgni*bp.zPos[abs(i)];
-    double zipls1     = sgni*bp.zPos[abs(i+1)];
-    double riLower    = bp.radiusLower[abs(i)];
-    double ripls1Lower= bp.radiusLower[abs(i+1)];
-    double riUpper    = bp.radiusUpper[abs(i)];
-    double ripls1Upper= bp.radiusUpper[abs(i+1)];
-    double tiltLower  = (sgni<0) ? -bp.getTiltLower(abs(i+1)) : +bp.getTiltLower(abs(i));
-    double tiltUpper  = (sgni<0) ? -bp.getTiltUpper(abs(i+1)) : +bp.getTiltUpper(abs(i));
+    for (unsigned int iHit=0; iHit<hitMaterialVec.size(); iHit++) {
 
-    double rPosLower = -1;
-    double rPosUpper = -1;
-    double zPosLower = -1;
-    double zPosUpper = -1;
-
-    // Tilt differen from +-pi/2 (@ pi/2 formulae based on zPos diverge)
-    if (zi!=zipls1) {
-
-      zPosUpper = (tan(theta)*z0 - tan(tiltUpper)*zi + riUpper)/(tan(theta) -tan(tiltUpper));
-      zPosLower = (tan(theta)*z0 - tan(tiltLower)*zi + riLower)/(tan(theta) -tan(tiltLower));
-
-      if ( ((zPosLower>=0) && (zPosLower>=zi) && (zPosLower<zipls1)) ||
-         ((zPosLower<0)  && (zPosLower<zi)  && (zPosLower>=zipls1)) ) rPosLower = tan(theta)*(zPosLower-z0);
-
-      if ( ((zPosUpper>=0) && (zPosUpper>=zi) && (zPosUpper<zipls1)) ||
-         ((zPosUpper<0)  && (zPosUpper<zi)  && (zPosUpper>=zipls1)) ) rPosUpper = tan(theta)*(zPosUpper-z0);
-    }
-    // Tilt = +-pi/2, formulae based on zPos diverge -> use different approach
-    else {
-
-      double rPos = tan(theta)*(zi-z0);
-
-      if ( (rPos>=MIN(riLower,ripls1Lower)) && (rPos<MAX(riLower,ripls1Lower)) ) {
-
-        zPosLower = zi;
-        rPosLower = rPos;
-      }
-      if ( (rPos>=MIN(riUpper,ripls1Upper)) && (rPos<MAX(riUpper,ripls1Upper)) ) {
-
-        zPosUpper = zi;
-        rPosUpper = rPos;
-      }
-    }
-
-    // Save individual points of crossings with beam-pipe contours
-    if (rPosLower!=-1 || rPosUpper!=-1) {
-
-      bpZRUpper.push_back(std::pair<double,double>(zPosUpper,rPosUpper));
-      bpZRLower.push_back(std::pair<double,double>(zPosLower,rPosLower));
-
-      // Material
-      //
-      // Positive z -> use directly index i to find material of corresponding segment
-      if (i>=0) bpRadIntLength.push_back(std::pair<double,double>(bp.radLength[i],bp.intLength[i]));
-      // Negative z -> use abs(i) -1 (indicis start at -(N-segments+1) and end-up at (-1) to find material of corresponding segment
-      else      bpRadIntLength.push_back(std::pair<double,double>(bp.radLength[abs(i)-1],bp.intLength[abs(i)-1]));
-    }
-  }
-
-  //
-  // Form hits from crossed points -> hit defined by average of two consecutive crossed points (maybe cross-points from lower & upper
-  // contours or lower only/upper only contours)
-  //
-  // Check that cross-points algorithm created points correctly first
-  if (bpZRLower.size()!=bpZRUpper.size()) {
-
-    std::ostringstream message;
-    message << "Beam-pipe algorithm assigning material not working correctly, check the code!";
-    throw PathfulException(message.str(), "VisitorMatBudget");
-  }
-  // Form hits
-  else {
-
-    for (unsigned int i=0; i<bpZRLower.size(); i++) {
-
-      double pathLength  = 0;
-      double rPosAvg     = 0;
-      double zPosAvg     = 0;
-      double radMaterial = -1;
-      double intMaterial = -1;
-
-      double zPosUpper = bpZRUpper[i].first;
-      double zPosLower = bpZRLower[i].first;
-      double rPosUpper = bpZRUpper[i].second;
-      double rPosLower = bpZRLower[i].second;
-      double radLength = bpRadIntLength[i].first;
-      double intLength = bpRadIntLength[i].second;
-
-      // Upper & Lower crossed
-      if (rPosLower!=-1 && rPosUpper!=-1) {
-
-        pathLength  = sqrt(pow(rPosUpper-rPosLower,2)+pow(zPosUpper-zPosLower,2));
-        rPosAvg     = (rPosUpper+rPosLower)/2.;
-        zPosAvg     = (zPosUpper+zPosLower)/2.;
-        radMaterial = pathLength/radLength;
-        intMaterial = pathLength/intLength;
-
-      }
-      // Upper or lower & next(next) upper or lower crossed -> update current point index by the found next(next) crossing point
-      else if ( (rPosLower==-1 && rPosUpper!=-1) || (rPosLower!=-1 && rPosUpper==-1)) {
-
-        // Look for next, next-next, next-next-next etc., set once found!
-        bool found = false;
-        while (!found) {
-
-          i++; // Get next point
-
-          if (i>=bpZRLower.size()) {
-            logERROR("BeamPipe not defined as a closed object, can't find all hit part!!!");
-            break;
-          }
-          else {
-
-            // Only one of these must be different from -1
-            double zPosUpperNext = bpZRUpper[i].first;
-            double zPosLowerNext = bpZRLower[i].first;
-            double rPosUpperNext = bpZRUpper[i].second;
-            double rPosLowerNext = bpZRLower[i].second;
-            double radLengthNext = bpRadIntLength[i].first;
-            double intLengthNext = bpRadIntLength[i].second;
-
-            // Different combinations may appear, but at least one of these: upper with upper or lower with upper or lower with lower
-            if      (rPosUpperNext!=-1 && rPosLowerNext!=-1) logERROR("Algorithmic problem when looking for material hits, check the code!!!");
-            else if (rPosUpperNext!=-1) {
-
-              if (rPosLower!=-1) {
-                pathLength = sqrt(pow(rPosUpperNext-rPosLower,2)+pow(zPosUpperNext-zPosLower,2));
-                rPosAvg    = (rPosUpperNext+rPosLower)/2.;
-                zPosAvg    = (zPosUpperNext+zPosLower)/2.;
-                found      = true;
-              }
-              else {
-                pathLength = sqrt(pow(rPosUpperNext-rPosUpper,2)+pow(zPosUpperNext-zPosUpper,2));
-                rPosAvg    = (rPosUpperNext+rPosUpper)/2.;
-                zPosAvg    = (zPosUpperNext+zPosUpper)/2.;
-                found      = true;
-              }
-            }
-            else if (rPosLowerNext!=-1) {
-
-              if (rPosLower!=-1) {
-                pathLength = sqrt(pow(rPosLowerNext-rPosLower,2)+pow(zPosLowerNext-zPosLower,2));
-                rPosAvg    = (rPosLowerNext+rPosLower)/2.;
-                zPosAvg    = (zPosLowerNext+zPosLower)/2.;
-                found      = true;
-              }
-              else {
-                pathLength = sqrt(pow(rPosLowerNext-rPosUpper,2)+pow(zPosLowerNext-zPosUpper,2));
-                rPosAvg    = (rPosLowerNext+rPosUpper)/2.;
-                zPosAvg    = (zPosLowerNext+zPosUpper)/2.;
-                found      = true;
-              }
-            }
-
-            // Check that material consistently defined: crossed-points forming the potential hit must be within the same material
-            if (radLength!=radLengthNext || intLength!=intLengthNext) {
-              logERROR("Algorithmic problem when looking for material hits: 2 crossed-points forming a potential hit not within the same material -> Check that Beam-pipe upper contour closing object & material definition!!!");
-            }
-            else {
-              radMaterial = pathLength/radLength;
-              intMaterial = pathLength/intLength;
-            }
-          }
-        } // While
-      }
-      else {
-
-        continue;
-      }
-
-      HitPtr hit(new Hit(rPosAvg, zPosAvg, nullptr, HitPassiveType::BeamPipe));
+      // Create corresponding hit
+      double rPos = hitPosVec[iHit]->Rho();
+      double zPos = hitPosVec[iHit]->Z();
 
       Material material;
-      material.radiation   = radMaterial;
-      material.interaction = intMaterial;
+      material.interaction = hitMaterialVec[iHit]->interaction;
+      material.radiation   = hitMaterialVec[iHit]->radiation;
 
+      HitPtr hit(new Hit(rPos, zPos, nullptr, HitPassiveType::BeamPipe));
       hit->setCorrectedMaterial(material);
       m_matTrack.addHit(std::move(hit));
 
-    } // For
-  } // Form hits algorithm
+      // Clear memory from temporary vectors
+      delete hitPosVec[iHit];
+      hitPosVec[iHit] = nullptr;
+      delete hitMaterialVec[iHit];
+      hitMaterialVec[iHit] = nullptr;
+    }
+  }
 }
 
 //

--- a/source/delphize.cc
+++ b/source/delphize.cc
@@ -241,10 +241,8 @@ int main(int argc, char* argv[]) {
     // First profile -> get eta, rescale bins, ...
     TProfile* exampleProfile = itPtProfiles->second;
 
-    double maxEta = exampleProfile->GetXaxis()->GetXmax();
-    VDUMP(maxEta);
-    double minEta = exampleProfile->GetXaxis()->GetXmin();
-    VDUMP(minEta);
+    VDUMP(exampleProfile->GetXaxis()->GetXmax());
+    VDUMP(exampleProfile->GetXaxis()->GetXmin());
     double originalEtaStep = exampleProfile->GetXaxis()->GetBinWidth(1);
     VDUMP(originalEtaStep);
     int rebinScale = etaSlice / originalEtaStep;


### PR DESCRIPTION
* Update formula to extract resolutions. Improvements to text header (by Will)
* Due to compatibility reasons, beam-pipe geometry may be defined as a 2D object (original) or 3D object (new).
 -- The way, how the geometry is built is defined in SimParms config file, using use3DBeamPipe variable.
 -- Implicitely 2D is assumed if no use3DBeamPipe variable is used in SimParms file.
 -- 2D beam-pipe geometry assumes phi symmetry, in R-Z the beam-pipe shape is defined by a sequence of [r,z] points, hence tilted shape is supported etc.
 -- 3D beam-pipe geometry assumes also phi symmetry, in R-Z the beam-pipe shape is defined by a sequence of 2 [r,z] contours, the path-length is then given directly as a difference of upper & lower cross-points. Hence 3D.